### PR TITLE
Fix handling of variable length maps and lists

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -194,3 +194,12 @@ fn test_option_none_roundtrip() {
 
     assert_eq!(obj1, obj2.unwrap());
 }
+
+#[test]
+fn test_variable_length_map() {
+    let slice = b"\xbf\x67\x6d\x65\x73\x73\x61\x67\x65\x64\x70\x6f\x6e\x67\xff";
+    let value: Value = de::from_slice(slice).unwrap();
+    let mut map = HashMap::new();
+    map.insert(ObjectKey::String("message".to_string()), Value::String("pong".to_string()));
+    assert_eq!(value, Value::Object(map))
+}

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -86,3 +86,16 @@ fn test_newtype_struct() {
     assert_eq!(to_vec(&142u8).unwrap(), to_vec(&Newtype(142u8)).unwrap());
     assert_eq!(from_slice::<Newtype>(&[24, 142]).unwrap(), Newtype(142));
 }
+
+#[derive(Deserialize, PartialEq, Debug)]
+enum Foo {
+    #[serde(rename = "require")]
+    Require,
+}
+
+#[test]
+fn test_variable_length_array() {
+    let slice = b"\x9F\x67\x72\x65\x71\x75\x69\x72\x65\xFF";
+    let value: Vec<Foo> = from_slice(slice).unwrap();
+    assert_eq!(value, [Foo::Require]);
+}


### PR DESCRIPTION
This feels a bit gross - is there a nicer way of handling stop words?

Closes #24