### PR TITLE
impl From for all ObjectKey and Value variants

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -583,3 +583,52 @@ impl From<Value> for ObjectKey {
     }
 }
 
+macro_rules! impl_from {
+    ($enum:ident, $variant:ident, $type:ty) => (
+        impl From<$type> for $enum {
+            fn from (v: $type) -> $enum {
+                $enum::$variant(v)
+            }
+        }
+    )
+}
+
+// All except &'a str and Cow<'a, str>
+impl_from!(ObjectKey, Integer, i64);
+impl_from!(ObjectKey, Bytes, Vec<u8>);
+impl_from!(ObjectKey, String, String);
+impl_from!(ObjectKey, Bool, bool);
+
+// All except &'a str and Cow<'a, str>
+impl_from!(Value, U64, u64);
+impl_from!(Value, I64, i64);
+impl_from!(Value, Bytes, Vec<u8>);
+impl_from!(Value, String, String);
+impl_from!(Value, Array, Vec<Value>);
+impl_from!(Value, Object, HashMap<ObjectKey, Value>);
+impl_from!(Value, F64, f64);
+impl_from!(Value, Bool, bool);
+
+impl<'a> From<&'a str> for ObjectKey {
+    fn from(s: &'a str) -> ObjectKey {
+        ObjectKey::String(s.to_string())
+    }
+}
+
+impl<'a> From<::std::borrow::Cow<'a, str>> for ObjectKey {
+    fn from(s: ::std::borrow::Cow<'a, str>) -> ObjectKey {
+        ObjectKey::String(s.to_string())
+    }
+}
+
+impl<'a> From<&'a str> for Value {
+    fn from(s: &'a str) -> Value {
+        Value::String(s.to_string())
+    }
+}
+
+impl<'a> From<::std::borrow::Cow<'a, str>> for Value {
+    fn from(s: ::std::borrow::Cow<'a, str>) -> Value {
+        Value::String(s.to_string())
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -584,10 +584,10 @@ impl From<Value> for ObjectKey {
 }
 
 macro_rules! impl_from {
-    ($enum:ident, $variant:ident, $type:ty) => (
-        impl From<$type> for $enum {
-            fn from (v: $type) -> $enum {
-                $enum::$variant(v)
+    ($for_enum:ident, $variant:ident, $for_type:ty) => (
+        impl From<$for_type> for $for_enum {
+            fn from (v: $for_type) -> $for_enum {
+                $for_enum::$variant(v)
             }
         }
     )


### PR DESCRIPTION
To be perfectly honest, I'm not sure if these changes are useful or wanted, but since I've made them, I figured I would submit a pull request to find out. :-)

I wrote this horrendous piece of code, and figured there had to be *some* way to shorten/unclutter it:

```
if let Some(obj) = value.as_object() {
    if obj.contains_key(&ObjectKey::String("error".to_string())) {
        // The horror! These unwraps should never fail though, as both keys always exist together, and both values are always strings.
        let error = format!("received an error response: {}: {}", obj.get(&ObjectKey::String("error".to_string())).unwrap().as_string().unwrap(),
                                                                  obj.get(&ObjectKey::String("error_description".to_string())).unwrap().as_string().unwrap());

        return Err(From::from(error));
    }
}
```

The best I could come up with was to replace e.g. `&ObjectKey::String("error".to_string())` with `"error".into()`, so I implemented what was required for that to work.

Critique and overall soundness checks are very welcome; I'm not very used to contributing to others' code whatsoever.