### PR TITLE
Fix tuple deserialization from indefinite-length array

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -213,3 +213,17 @@ fn test_object_determinism_roundtrip() {
         assert_eq!(&to_vec(&de::from_slice::<Value>(expected).unwrap()).unwrap(), expected);
     }
 }
+
+#[test]
+fn test_tuple_from_array() {
+    let bytes = [0x83, 0x01, 0x02, 0x03];
+    let result: (i64, i64, i64) = serde_cbor::de::from_slice(&bytes).unwrap();
+    assert_eq!((1, 2, 3), result)
+}
+
+#[test]
+fn test_tuple_from_indefinite_length_array() {
+    let bytes = [0x9f, 0x01, 0x02, 0x03, 0xff];
+    let result: (i64, i64, i64) = serde_cbor::de::from_slice(&bytes).unwrap();
+    assert_eq!((1, 2, 3), result)
+}


### PR DESCRIPTION
Serde only calls `next_element` n times for a tuple of n elements (https://github.com/serde-rs/serde/blob/master/serde/src/de/impls.rs#L749), therefore we never consume the delimiter when deserializing into tuples from indefinite-length arrays.