### PR TITLE
Got rid of MAX_SEQ_LEN (fixes #39)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,8 @@ use serde::ser;
 pub enum Error {
     /// The CBOR value had a syntactic error.
     Syntax,
+    /// The size of the sequence/mapping/buffer is larger than usize
+    SizeError,
     /// Some IO error occured when processing a value.
     Io(io::Error),
     /// Some error occured while converting a string.
@@ -32,6 +34,7 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Syntax => "syntax error",
+            Error::SizeError => "size error",
             Error::Io(ref error) => StdError::description(error),
             Error::FromUtf8(ref error) => error.description(),
             Error::Custom(ref s) => s,


### PR DESCRIPTION
Another attempt to fix #39. Looks easy. I'm not sure about initial vector capacity, but otherwise patch is quite simple.

Note: serde itself caps `size_hint` to 4096 when serializing (i.e. doesn't allocate more than 4096 items up front)