### PR TITLE
Major rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.15.1
+- 1.18.0
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ description = "UNMAINTAINED: CBOR serialization and deserialization using serde.
 keywords = ["serde", "cbor", "serialization"]
 
 [dependencies]
-byteorder = "1.0"
-serde = "1.0.0"
-serde_bytes = "0.10.0"
+byteorder = "1.0.0"
+serde = "1.0.14"
 
 [dev-dependencies]
-serde_derive = "1.0.0"
+serde_bytes = "0.10"
+serde_derive = "1.0.14"

--- a/src/de.rs
+++ b/src/de.rs
@@ -549,7 +549,7 @@ where
                 self.parse_u64()?;
                 self.parse_value(visitor)
             }
-            0xde...0xdf => Err(self.error(ErrorCode::UnassignedCode)),
+            0xdc...0xdf => Err(self.error(ErrorCode::UnassignedCode)),
 
             // Major type 7: floating-point numbers and other simple data types that need no content
             0xe0...0xf3 => Err(self.error(ErrorCode::UnassignedCode)),

--- a/src/de.rs
+++ b/src/de.rs
@@ -130,6 +130,7 @@ where
     where
         V: de::Visitor<'de>,
     {
+        self.buf.clear();
         match self.read.read(len, &mut self.buf, 0)? {
             Reference::Borrowed(buf) => visitor.visit_borrowed_bytes(buf),
             Reference::Copied => visitor.visit_bytes(&self.buf),
@@ -141,6 +142,7 @@ where
         V: de::Visitor<'de>,
     {
         let mut offset = 0;
+        self.buf.clear();
         loop {
             let byte = self.parse_u8()?;
             let len = match byte {
@@ -191,6 +193,7 @@ where
     where
         V: de::Visitor<'de>,
     {
+        self.buf.clear();
         match self.read.read(len, &mut self.buf, 0)? {
             Reference::Borrowed(buf) => {
                 let s = self.convert_str(buf)?;
@@ -208,6 +211,7 @@ where
         V: de::Visitor<'de>,
     {
         let mut offset = 0;
+        self.buf.clear();
         loop {
             let byte = self.parse_u8()?;
             let len = match byte {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,15 +129,19 @@
 #![deny(missing_docs)]
 
 extern crate byteorder;
+
+#[macro_use]
 extern crate serde;
-extern crate serde_bytes;
 
-pub use de::{from_slice, from_reader};
-pub use error::{Error, Result};
-pub use ser::to_vec;
-pub use value::{Value, ObjectKey};
-
+mod read;
 pub mod de;
 pub mod error;
 pub mod ser;
 pub mod value;
+
+#[doc(inline)]
+pub use de::{from_slice, from_reader, Deserializer};
+#[doc(inline)]
+pub use ser::{to_writer, to_vec, Serializer};
+#[doc(inline)]
+pub use value::{Value, ObjectKey};

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,0 +1,258 @@
+use std::io::{self, Read as StdRead};
+
+use error::{Result, Error, ErrorCode};
+
+/// Trait used by the deserializer for iterating over input.
+///
+/// This trait is sealed and cannot be implemented for types outside of `serde_cbor`.
+pub trait Read<'de>: private::Sealed {
+    #[doc(hidden)]
+    fn next(&mut self) -> io::Result<Option<u8>>;
+    #[doc(hidden)]
+    fn peek(&mut self) -> io::Result<Option<u8>>;
+
+    #[doc(hidden)]
+    fn read(
+        &mut self,
+        n: usize,
+        scratch: &mut Vec<u8>,
+        scratch_offset: usize,
+    ) -> Result<Reference<'de>>;
+
+    #[doc(hidden)]
+    fn read_into(&mut self, buf: &mut [u8]) -> Result<()>;
+
+    #[doc(hidden)]
+    fn discard(&mut self);
+
+    #[doc(hidden)]
+    fn offset(&self) -> u64;
+}
+
+pub enum Reference<'b> {
+    Borrowed(&'b [u8]),
+    Copied,
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// CBOR input source that reads from a std::io input stream.
+pub struct IoRead<R>
+where
+    R: io::Read,
+{
+    reader: OffsetReader<R>,
+    ch: Option<u8>,
+}
+
+impl<R> IoRead<R>
+where
+    R: io::Read,
+{
+    /// Creates a new CBOR input source to read from a std::io input stream.
+    pub fn new(reader: R) -> IoRead<R> {
+        IoRead {
+            reader: OffsetReader {
+                reader: reader,
+                offset: 0,
+            },
+            ch: None,
+        }
+    }
+
+    #[inline]
+    fn next_inner(&mut self) -> io::Result<Option<u8>> {
+        let mut buf = [0; 1];
+        loop {
+            match self.reader.read(&mut buf) {
+                Ok(0) => return Ok(None),
+                Ok(_) => return Ok(Some(buf[0])),
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl<R> private::Sealed for IoRead<R>
+where
+    R: io::Read,
+{
+}
+
+impl<'de, R> Read<'de> for IoRead<R>
+where
+    R: io::Read,
+{
+    #[inline]
+    fn next(&mut self) -> io::Result<Option<u8>> {
+        match self.ch.take() {
+            Some(ch) => Ok(Some(ch)),
+            None => self.next_inner(),
+        }
+    }
+
+    #[inline]
+    fn peek(&mut self) -> io::Result<Option<u8>> {
+        match self.ch {
+            Some(ch) => Ok(Some(ch)),
+            None => {
+                self.ch = self.next_inner()?;
+                Ok(self.ch)
+            }
+        }
+    }
+
+    fn read(
+        &mut self,
+        n: usize,
+        scratch: &mut Vec<u8>,
+        mut scratch_offset: usize,
+    ) -> Result<Reference<'de>> {
+        if n == 0 {
+            return Ok(Reference::Copied);
+        }
+
+        if n > scratch.len() - scratch_offset {
+            scratch.resize(scratch_offset + n, 0);
+        }
+
+        if let Some(ch) = self.ch.take() {
+            scratch[scratch_offset] = ch;
+            scratch_offset += 1;
+        }
+
+        self.read_into(&mut scratch[scratch_offset..])?;
+
+        Ok(Reference::Copied)
+    }
+
+    fn read_into(&mut self, mut buf: &mut [u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.reader.read(buf) {
+                Ok(0) => {
+                    return Err(Error::syntax(
+                        ErrorCode::EofWhileParsingValue,
+                        self.offset(),
+                    ))
+                }
+                Ok(count) => {
+                    buf = &mut {
+                        buf
+                    }[count..]
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(Error::io(e)),
+            }
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn discard(&mut self) {
+        self.ch = None;
+    }
+
+    fn offset(&self) -> u64 {
+        self.reader.offset
+    }
+}
+
+struct OffsetReader<R> {
+    reader: R,
+    offset: u64,
+}
+
+impl<R> io::Read for OffsetReader<R>
+where
+    R: io::Read,
+{
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let r = self.reader.read(buf);
+        if let Ok(count) = r {
+            self.offset += count as u64;
+        }
+        r
+    }
+}
+
+/// A CBOR input source that reads from a slice of bytes.
+pub struct SliceRead<'a> {
+    slice: &'a [u8],
+    index: usize,
+}
+
+impl<'a> SliceRead<'a> {
+    /// Creates a CBOR input source to read from a slice of bytes.
+    pub fn new(slice: &'a [u8]) -> SliceRead<'a> {
+        SliceRead {
+            slice: slice,
+            index: 0,
+        }
+    }
+
+    fn end(&self, n: usize) -> Result<usize> {
+        match self.index.checked_add(n) {
+            Some(end) if end <= self.slice.len() => Ok(end),
+            _ => {
+                Err(Error::syntax(
+                    ErrorCode::EofWhileParsingValue,
+                    self.slice.len() as u64,
+                ))
+            }
+        }
+    }
+}
+
+impl<'a> private::Sealed for SliceRead<'a> {}
+
+impl<'a> Read<'a> for SliceRead<'a> {
+    #[inline]
+    fn next(&mut self) -> io::Result<Option<u8>> {
+        Ok(if self.index < self.slice.len() {
+            let ch = self.slice[self.index];
+            self.index += 1;
+            Some(ch)
+        } else {
+            None
+        })
+    }
+
+    #[inline]
+    fn peek(&mut self) -> io::Result<Option<u8>> {
+        Ok(if self.index < self.slice.len() {
+            Some(self.slice[self.index])
+        } else {
+            None
+        })
+    }
+
+    #[inline]
+    fn read(&mut self, n: usize, _: &mut Vec<u8>, _: usize) -> Result<Reference<'a>> {
+        let end = self.end(n)?;
+        let slice = &self.slice[self.index..end];
+        self.index = end;
+        Ok(Reference::Borrowed(slice))
+    }
+
+    #[inline]
+    fn read_into(&mut self, buf: &mut [u8]) -> Result<()> {
+        let end = self.end(buf.len())?;
+        buf.copy_from_slice(&self.slice[self.index..end]);
+        self.index = end;
+        Ok(())
+    }
+
+    #[inline]
+    fn discard(&mut self) {
+        self.index += 1;
+    }
+
+    fn offset(&self) -> u64 {
+        self.index as u64
+    }
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,404 +1,357 @@
-//! CBOR serializisation.
+//! Serialize a Rust data structure to CBOR data.
+use byteorder::{ByteOrder, BigEndian};
+use serde::ser::{self, Serialize};
+use std::io;
 
-use std::io::Write;
+use error::{Error, Result};
 
-use byteorder::{BigEndian, WriteBytesExt};
-use serde::ser::{self, Serialize, Serializer as SerdeSerializer};
+/// Serializes a value to a writer.
+pub fn to_writer<W, T>(mut writer: &mut W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    value.serialize(&mut Serializer::new(&mut writer))
+}
 
-use {Error, Result};
+/// Serializes a value to a writer and adds a CBOR self-describe tag.
+pub fn to_writer_sd<W, T>(mut writer: &mut W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    let mut ser = Serializer::new(&mut writer);
+    ser.self_describe()?;
+    value.serialize(&mut ser)
+}
 
-/// A structure for serializing Rust values into CBOR.
-pub struct Serializer<W: Write> {
+/// Serializes a value without names to a writer.
+///
+/// Struct fields and enum variants are identified by their numeric indices rather than names to
+/// save space.
+pub fn to_writer_packed<W, T>(mut writer: &mut W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    value.serialize(&mut Serializer::packed(&mut writer))
+}
+
+/// Serializes a value without names to a writer and adds a CBOR self-describe tag.
+///
+/// Struct fields and enum variants are identified by their numeric indices rather than names to
+/// save space.
+pub fn to_writer_packed_sd<W, T>(mut writer: &mut W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    let mut ser = Serializer::packed(&mut writer);
+    ser.self_describe()?;
+    value.serialize(&mut ser)
+}
+
+/// Serializes a value to a vector.
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::new();
+    to_writer(&mut vec, value)?;
+    Ok(vec)
+}
+
+/// Serializes a value to a vector and adds a CBOR self-describe tag.
+pub fn to_vec_sd<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::new();
+    to_writer_sd(&mut vec, value)?;
+    Ok(vec)
+}
+
+/// Serializes a value without names to a vector.
+///
+/// Struct fields and enum variants are identified by their numeric indices rather than names to
+/// save space.
+pub fn to_vec_packed<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::new();
+    to_writer_packed(&mut vec, value)?;
+    Ok(vec)
+}
+/// Serializes a value without names to a vector and adds a CBOR self-describe tag.
+///
+/// Struct fields and enum variants are identified by their numeric indices rather than names to
+/// save space.
+pub fn to_vec_packed_sd<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::new();
+    to_writer_packed_sd(&mut vec, value)?;
+    Ok(vec)
+}
+
+/// A structure for serializing Rust values to CBOR.
+pub struct Serializer<W> {
     writer: W,
     packed: bool,
 }
 
-impl<W: Write> Serializer<W> {
+impl<W> Serializer<W>
+where
+    W: io::Write,
+{
     /// Creates a new CBOR serializer.
+    #[inline]
     pub fn new(writer: W) -> Serializer<W> {
         Serializer {
-            writer: writer,
+            writer,
             packed: false,
         }
     }
 
-    /// Creates a new packed CBOR serializer.
+    /// Creates a new "packed" CBOR serializer.
     ///
-    /// In packed mode all struct field names and enum variant names
-    /// are not serialized instead the index position of the field
-    /// is used.
+    /// Struct fields and enum variants are identified by their numeric indices rather than names
+    /// to save space.
+    #[inline]
     pub fn packed(writer: W) -> Serializer<W> {
         Serializer {
-            writer: writer,
+            writer,
             packed: true,
         }
     }
 
-    /// Writes the CBOR self-describe tag to the stream.
+    /// Writes a CBOR self-describe tag to the stream.
     ///
-    /// Tagging allows a decoder to distinguish different file formats
-    /// based on their content without other information.
+    /// Tagging allows a decoder to distinguish different file formats based on their content
+    /// without further information.
+    #[inline]
     pub fn self_describe(&mut self) -> Result<()> {
-        self.writer.write_u8(6 << 5 | 25)?;
-        self.writer.write_u16::<BigEndian>(55799)?;
-        Ok(())
+        let mut buf = [6 << 5 | 25, 0, 0];
+        BigEndian::write_u16(&mut buf[1..], 55799);
+        self.writer.write_all(&buf).map_err(Error::io)
+    }
+
+    /// Unwrap the `Writer` from the `Serializer`.
+    #[inline]
+    pub fn into_inner(self) -> W {
+        self.writer
     }
 
     #[inline]
-    fn write_type_u8(&mut self, major: u8, additional: u8) -> Result<()> {
-        if additional > 23 {
-            self.writer.write_u8(major << 5 | 24)?;
-            self.writer.write_u8(additional)?;
+    fn write_u8(&mut self, major: u8, value: u8) -> Result<()> {
+        if value <= 0x17 {
+            self.writer.write_all(&[major << 5 | value])
         } else {
-            self.writer.write_u8(major << 5 | additional)?;
-        }
-        Ok(())
+            let buf = [major << 5 | 24, value];
+            self.writer.write_all(&buf)
+        }.map_err(Error::io)
     }
 
     #[inline]
-    fn write_type_u16(&mut self, major: u8, additional: u16) -> Result<()> {
-        if additional > ::std::u8::MAX as u16 {
-            self.writer.write_u8(major << 5 | 25)?;
-            self.writer.write_u16::<BigEndian>(additional)?;
+    fn write_u16(&mut self, major: u8, value: u16) -> Result<()> {
+        if value <= u8::max_value() as u16 {
+            self.write_u8(major, value as u8)
         } else {
-            self.write_type_u8(major, additional as u8)?;
-        }
-        Ok(())
-    }
-
-    #[inline]
-    fn write_type_u32(&mut self, major: u8, additional: u32) -> Result<()> {
-        if additional > ::std::u16::MAX as u32 {
-            self.writer.write_u8(major << 5 | 26)?;
-            self.writer.write_u32::<BigEndian>(additional)?;
-        } else {
-            self.write_type_u16(major, additional as u16)?;
-        }
-        Ok(())
-    }
-
-    #[inline]
-    fn write_type_u64(&mut self, major: u8, additional: u64) -> Result<()> {
-        if additional > ::std::u32::MAX as u64 {
-            self.writer.write_u8(major << 5 | 27)?;
-            self.writer.write_u64::<BigEndian>(additional)?;
-        } else {
-            self.write_type_u32(major, additional as u32)?;
-        }
-        Ok(())
-    }
-
-    #[inline]
-    fn write_collection_start(&mut self,
-                              major: u8,
-                              len: Option<usize>)
-                              -> Result<Compound<W, CollectionState>> {
-        if let Some(len) = len {
-            self.write_type_u64(major, len as u64)?;
-            Ok(Compound {
-                   ser: self,
-                   state: CollectionState::Fixed,
-               })
-        } else {
-            self.writer.write_u8(major << 5 | 31)?;
-            Ok(Compound {
-                   ser: self,
-                   state: CollectionState::Indefinite,
-               })
+            let mut buf = [major << 5 | 25, 0, 0];
+            BigEndian::write_u16(&mut buf[1..], value);
+            self.writer.write_all(&buf).map_err(Error::io)
         }
     }
 
     #[inline]
-    fn write_collection_end(&mut self, state: CollectionState) -> Result<()> {
-        match state {
-            CollectionState::Fixed => Ok(()),
-            CollectionState::Indefinite => self.writer.write_u8(0xff).map_err(From::from),
-        }
-    }
-}
-
-#[doc(hidden)]
-pub enum CollectionState {
-    Fixed,
-    Indefinite,
-}
-
-#[doc(hidden)]
-pub struct StructState {
-    counter: usize,
-}
-
-#[doc(hidden)]
-pub struct Compound<'a, W: 'a + Write, S> {
-    ser: &'a mut Serializer<W>,
-    state: S,
-}
-
-impl<'a, W: Write> ser::SerializeSeq for Compound<'a, W, CollectionState> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut *self.ser)
-    }
-
-    fn end(self) -> Result<()> {
-        self.ser.write_collection_end(self.state)
-    }
-}
-
-impl<'a, W: Write> ser::SerializeTuple for &'a mut Serializer<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a, W: Write> ser::SerializeTupleStruct for &'a mut Serializer<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a, W: Write> ser::SerializeTupleVariant for &'a mut Serializer<W> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a, W: Write> ser::SerializeMap for Compound<'a, W, CollectionState> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut *self.ser)
-    }
-
-    fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
-        value.serialize(&mut *self.ser)
-    }
-
-    fn end(self) -> Result<()> {
-        self.ser.write_collection_end(self.state)
-    }
-}
-
-impl<'a, W: Write> ser::SerializeStruct for Compound<'a, W, StructState> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self,
-                                                   key: &'static str,
-                                                   value: &T)
-                                                   -> Result<()> {
-        if !self.ser.packed {
-            self.ser.serialize_str(key)?;
+    fn write_u32(&mut self, major: u8, value: u32) -> Result<()> {
+        if value <= u16::max_value() as u32 {
+            self.write_u16(major, value as u16)
         } else {
-            self.ser.serialize_u64(self.state.counter as u64)?;
+            let mut buf = [major << 5 | 26, 0, 0, 0, 0];
+            BigEndian::write_u32(&mut buf[1..], value);
+            self.writer.write_all(&buf).map_err(Error::io)
         }
-        value.serialize(&mut *self.ser)?;
-        self.state.counter += 1;
-        Ok(())
     }
 
-    fn end(self) -> Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a, W: Write> ser::SerializeStructVariant for Compound<'a, W, StructState> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self,
-                                                   key: &'static str,
-                                                   value: &T)
-                                                   -> Result<()> {
-        if !self.ser.packed {
-            self.ser.serialize_str(key)?;
+    #[inline]
+    fn write_u64(&mut self, major: u8, value: u64) -> Result<()> {
+        if value <= u32::max_value() as u64 {
+            self.write_u32(major, value as u32)
         } else {
-            self.ser.serialize_u64(self.state.counter as u64)?;
+            let mut buf = [major << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
+            BigEndian::write_u64(&mut buf[1..], value);
+            self.writer.write_all(&buf).map_err(Error::io)
         }
-        value.serialize(&mut *self.ser)?;
-        self.state.counter += 1;
-        Ok(())
     }
 
-    fn end(self) -> Result<()> {
-        Ok(())
+    #[inline]
+    fn serialize_collection<'a>(
+        &'a mut self,
+        major: u8,
+        len: Option<usize>,
+    ) -> Result<CollectionSerializer<'a, W>> {
+        let needs_eof = match len {
+            Some(len) => {
+                self.write_u64(major, len as u64)?;
+                false
+            }
+            None => {
+                self.writer.write_all(&[major << 5 | 31]).map_err(Error::io)?;
+                true
+            }
+        };
+
+        Ok(CollectionSerializer {
+            ser: self,
+            needs_eof,
+        })
     }
 }
 
-impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
+impl<'a, W> ser::Serializer for &'a mut Serializer<W>
+where
+    W: io::Write,
+{
     type Ok = ();
     type Error = Error;
-    type SerializeSeq = Compound<'a, W, CollectionState>;
+
+    type SerializeSeq = CollectionSerializer<'a, W>;
     type SerializeTuple = &'a mut Serializer<W>;
     type SerializeTupleStruct = &'a mut Serializer<W>;
     type SerializeTupleVariant = &'a mut Serializer<W>;
-    type SerializeMap = Compound<'a, W, CollectionState>;
-    type SerializeStruct = Compound<'a, W, StructState>;
-    type SerializeStructVariant = Compound<'a, W, StructState>;
+    type SerializeMap = CollectionSerializer<'a, W>;
+    type SerializeStruct = StructSerializer<'a, W>;
+    type SerializeStructVariant = StructSerializer<'a, W>;
 
     #[inline]
-    fn serialize_bool(self, v: bool) -> Result<()> {
-        self.writer
-            .write_u8(match v {
-                          false => 7 << 5 | 20,
-                          true => 7 << 5 | 21,
-                      })
-            .map_err(From::from)
+    fn serialize_bool(self, value: bool) -> Result<()> {
+        let value = if value { 0xf5 } else { 0xf4 };
+        self.writer.write_all(&[value]).map_err(Error::io)
     }
 
     #[inline]
-    fn serialize_i8(self, v: i8) -> Result<()> {
-        if v < 0 {
-            self.write_type_u8(1, -(v + 1) as u8)
+    fn serialize_i8(self, value: i8) -> Result<()> {
+        if value < 0 {
+            self.write_u8(1, -(value + 1) as u8)
         } else {
-            self.serialize_u8(v as u8)
+            self.write_u8(0, value as u8)
         }
     }
 
     #[inline]
-    fn serialize_i16(self, v: i16) -> Result<()> {
-        if v < 0 {
-            self.write_type_u16(1, -(v + 1) as u16)
+    fn serialize_i16(self, value: i16) -> Result<()> {
+        if value < 0 {
+            self.write_u16(1, -(value + 1) as u16)
         } else {
-            self.serialize_u16(v as u16)
+            self.write_u16(0, value as u16)
         }
     }
 
     #[inline]
-    fn serialize_i32(self, v: i32) -> Result<()> {
-        if v < 0 {
-            self.write_type_u32(1, -(v + 1) as u32)
+    fn serialize_i32(self, value: i32) -> Result<()> {
+        if value < 0 {
+            self.write_u32(1, -(value + 1) as u32)
         } else {
-            self.serialize_u32(v as u32)
+            self.write_u32(0, value as u32)
         }
     }
 
     #[inline]
-    fn serialize_i64(self, v: i64) -> Result<()> {
-        if v < 0 {
-            self.write_type_u64(1, -(v + 1) as u64)
+    fn serialize_i64(self, value: i64) -> Result<()> {
+        if value < 0 {
+            self.write_u64(1, -(value + 1) as u64)
         } else {
-            self.serialize_u64(v as u64)
+            self.write_u64(0, value as u64)
         }
     }
 
     #[inline]
-    fn serialize_u8(self, v: u8) -> Result<()> {
-        self.write_type_u8(0, v)
+    fn serialize_u8(self, value: u8) -> Result<()> {
+        self.write_u8(0, value)
     }
 
     #[inline]
-    fn serialize_u16(self, v: u16) -> Result<()> {
-        self.write_type_u16(0, v)
+    fn serialize_u16(self, value: u16) -> Result<()> {
+        self.write_u16(0, value)
     }
 
     #[inline]
-    fn serialize_u32(self, v: u32) -> Result<()> {
-        self.write_type_u32(0, v)
+    fn serialize_u32(self, value: u32) -> Result<()> {
+        self.write_u32(0, value)
     }
 
     #[inline]
-    fn serialize_u64(self, v: u64) -> Result<()> {
-        self.write_type_u64(0, v)
+    fn serialize_u64(self, value: u64) -> Result<()> {
+        self.write_u64(0, value)
     }
 
     #[inline]
-    fn serialize_f32(self, v: f32) -> Result<()> {
-        // TODO: Encode to f16
-        if v.is_infinite() && v.is_sign_positive() {
+    fn serialize_f32(self, value: f32) -> Result<()> {
+        if value.is_infinite() {
+            if value.is_sign_positive() {
                 self.writer.write_all(&[0xf9, 0x7c, 0x00])
-            } else if v.is_infinite() && v.is_sign_negative() {
-                self.writer.write_all(&[0xf9, 0xfc, 0x00])
-            } else if v.is_nan() {
-                self.writer.write_all(&[0xf9, 0x7e, 0x00])
             } else {
-                self.writer
-                    .write_u8(7 << 5 | 26)
-                    .and_then(|()| self.writer.write_f32::<BigEndian>(v))
+                self.writer.write_all(&[0xf9, 0xfc, 0x00])
             }
-            .map_err(From::from)
+        } else if value.is_nan() {
+            self.writer.write_all(&[0xf9, 0x7e, 0x00])
+        } else {
+            // TODO encode as f16 when possible
+            let mut buf = [0xfa, 0, 0, 0, 0];
+            BigEndian::write_f32(&mut buf[1..], value);
+            self.writer.write_all(&buf)
+        }.map_err(Error::io)
     }
 
     #[inline]
-    fn serialize_f64(self, v: f64) -> Result<()> {
-        // TODO: Encode to f16
-        if v.is_infinite() && v.is_sign_positive() {
-                self.writer.write_all(&[0xf9, 0x7c, 0x00])
-            } else if v.is_infinite() && v.is_sign_negative() {
-                self.writer.write_all(&[0xf9, 0xfc, 0x00])
-            } else if v.is_nan() {
-                self.writer.write_all(&[0xf9, 0x7e, 0x00])
-            } else if v as f32 as f64 == v {
-                self.writer
-                    .write_u8(7 << 5 | 26)
-                    .and_then(|()| self.writer.write_f32::<BigEndian>(v as f32))
-            } else {
-                self.writer
-                    .write_u8(7 << 5 | 27)
-                    .and_then(|()| self.writer.write_f64::<BigEndian>(v))
-            }
-            .map_err(From::from)
+    fn serialize_f64(self, value: f64) -> Result<()> {
+        if !value.is_finite() || value as f32 as f64 == value {
+            self.serialize_f32(value as f32)
+        } else {
+            let mut buf = [0xfb, 0, 0, 0, 0, 0, 0, 0, 0];
+            BigEndian::write_f64(&mut buf[1..], value);
+            self.writer.write_all(&buf).map_err(Error::io)
+        }
     }
 
     #[inline]
-    fn serialize_char(self, v: char) -> Result<()> {
-        // TODO: Avoid allocation. rust-lang/rust#27784
-        let mut s = String::new();
-        s.push(v);
-        self.serialize_str(s.as_str())
+    fn serialize_char(self, value: char) -> Result<()> {
+        // A char encoded as UTF-8 takes 4 bytes at most.
+        let mut buf = [0; 4];
+        self.serialize_str(value.encode_utf8(&mut buf))
     }
 
     #[inline]
     fn serialize_str(self, value: &str) -> Result<()> {
-        self.write_type_u64(3, value.len() as u64)?;
-        self.writer
-            .write_all(value.as_bytes())
-            .map_err(From::from)
+        self.write_u64(3, value.len() as u64)?;
+        self.writer.write_all(value.as_bytes()).map_err(Error::io)
     }
 
     #[inline]
     fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        self.write_type_u64(2, value.len() as u64)?;
-        self.writer.write_all(value).map_err(From::from)
-    }
-
-    #[inline]
-    fn serialize_none(self) -> Result<()> {
-        self.serialize_unit()
-    }
-
-    #[inline]
-    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<()> {
-        value.serialize(self)
+        self.write_u64(2, value.len() as u64)?;
+        self.writer.write_all(value).map_err(Error::io)
     }
 
     #[inline]
     fn serialize_unit(self) -> Result<()> {
-        self.writer.write_u8(7 << 5 | 22).map_err(From::from)
+        self.serialize_none()
+    }
+
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
+    fn serialize_none(self) -> Result<()> {
+        self.writer.write_all(&[0xf6]).map_err(Error::io)
     }
 
     #[inline]
@@ -407,151 +360,316 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     #[inline]
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              variant_index: u32,
-                              variant: &'static str)
-                              -> Result<()> {
-        if !self.packed {
-            self.serialize_str(variant)
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<()> {
+        if self.packed {
+            self.serialize_u32(variant_index)
         } else {
-            self.serialize_u64(variant_index as u64)
+            self.serialize_str(variant)
         }
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized + Serialize>(self,
-                                                       _name: &'static str,
-                                                       value: &T)
-                                                       -> Result<()> {
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
         value.serialize(self)
     }
 
     #[inline]
-    fn serialize_newtype_variant<T: ?Sized + Serialize>(self,
-                                                        name: &'static str,
-                                                        variant_index: u32,
-                                                        variant: &'static str,
-                                                        value: &T)
-                                                        -> Result<()> {
-        self.writer.write_u8(4 << 5 | 2)?;
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.writer.write_all(&[4 << 5 | 2]).map_err(Error::io)?;
         self.serialize_unit_variant(name, variant_index, variant)?;
         value.serialize(self)
     }
 
     #[inline]
-    fn serialize_seq(self, len: Option<usize>) -> Result<Compound<'a, W, CollectionState>> {
-        self.write_collection_start(4, len)
+    fn serialize_seq(self, len: Option<usize>) -> Result<CollectionSerializer<'a, W>> {
+        self.serialize_collection(4, len)
     }
 
     #[inline]
     fn serialize_tuple(self, len: usize) -> Result<&'a mut Serializer<W>> {
-        self.write_type_u64(4, len as u64)?;
+        self.write_u64(4, len as u64)?;
         Ok(self)
     }
 
     #[inline]
-    fn serialize_tuple_struct(self,
-                              _name: &'static str,
-                              len: usize)
-                              -> Result<&'a mut Serializer<W>> {
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<&'a mut Serializer<W>> {
         self.serialize_tuple(len)
     }
 
     #[inline]
-    fn serialize_tuple_variant(self,
-                               name: &'static str,
-                               variant_index: u32,
-                               variant: &'static str,
-                               len: usize)
-                               -> Result<&'a mut Serializer<W>> {
-        self.write_type_u64(4, (len + 1) as u64)?;
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<&'a mut Serializer<W>> {
+        self.write_u64(4, (len + 1) as u64)?;
         self.serialize_unit_variant(name, variant_index, variant)?;
         Ok(self)
     }
 
     #[inline]
-    fn serialize_map(self, len: Option<usize>) -> Result<Compound<'a, W, CollectionState>> {
-        self.write_collection_start(5, len)
+    fn serialize_map(self, len: Option<usize>) -> Result<CollectionSerializer<'a, W>> {
+        self.serialize_collection(5, len)
     }
 
     #[inline]
-    fn serialize_struct(self,
-                        _name: &'static str,
-                        len: usize)
-                        -> Result<Compound<'a, W, StructState>> {
-        self.write_type_u64(5, len as u64)?;
-        Ok(Compound {
-               ser: self,
-               state: StructState { counter: 0 },
-           })
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<StructSerializer<'a, W>> {
+        self.write_u64(5, len as u64)?;
+        Ok(StructSerializer {
+            ser: self,
+            idx: 0,
+        })
     }
 
     #[inline]
-    fn serialize_struct_variant(self,
-                                name: &'static str,
-                                variant_index: u32,
-                                variant: &'static str,
-                                len: usize)
-                                -> Result<Compound<'a, W, StructState>> {
-        self.writer.write_u8(4 << 5 | 2)?;
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<StructSerializer<'a, W>> {
+        self.writer.write_all(&[4 << 5 | 2]).map_err(Error::io)?;
         self.serialize_unit_variant(name, variant_index, variant)?;
-        self.write_type_u64(5, len as u64)?;
-        Ok(Compound {
-               ser: self,
-               state: StructState { counter: 0 },
-           })
+        self.serialize_struct(name, len)
     }
 }
 
-/// Serializes a value to a writer.
-pub fn to_writer<W: Write, T: Serialize>(mut writer: &mut W, value: &T) -> Result<()> {
-    value.serialize(&mut Serializer::new(&mut writer))
+impl<'a, W> ser::SerializeTuple for &'a mut Serializer<W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        Ok(())
+    }
 }
 
-/// Serializes a value to a writer and add a CBOR self-describe tag.
-pub fn to_writer_sd<W: Write, T: Serialize>(mut writer: &mut W, value: &T) -> Result<()> {
-    let mut ser = Serializer::new(&mut writer);
-    ser.self_describe()?;
-    value.serialize(&mut ser)
+impl<'a, W> ser::SerializeTupleStruct for &'a mut Serializer<W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        Ok(())
+    }
 }
 
-/// Serializes a value without names to a writer.
-pub fn to_writer_packed<W: Write, T: Serialize>(mut writer: &mut W, value: &T) -> Result<()> {
-    value.serialize(&mut Serializer::packed(&mut writer))
+impl<'a, W> ser::SerializeTupleVariant for &'a mut Serializer<W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        Ok(())
+    }
 }
 
-/// Serializes a value without names to a writer and add a CBOR self-describe tag.
-pub fn to_writer_packed_sd<W: Write, T: Serialize>(mut writer: &mut W, value: &T) -> Result<()> {
-    let mut ser = Serializer::packed(&mut writer);
-    ser.self_describe()?;
-    value.serialize(&mut ser)
+#[doc(hidden)]
+pub struct StructSerializer<'a, W: 'a> {
+    ser: &'a mut Serializer<W>,
+    idx: u32
 }
 
-/// Serializes a value to a vector.
-pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
-    let mut vec = Vec::new();
-    to_writer(&mut vec, value)?;
-    Ok(vec)
+impl<'a, W> StructSerializer<'a, W>
+where
+    W: io::Write,
+{
+    #[inline]
+    fn serialize_field_inner<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if self.ser.packed {
+            self.idx.serialize(&mut *self.ser)?;
+        } else {
+            key.serialize(&mut *self.ser)?;
+        }
+        self.idx += 1;
+        value.serialize(&mut *self.ser)
+    }
+
+    #[inline]
+    fn skip_field_inner(&mut self, _: &'static str) -> Result<()> {
+        self.idx += 1;
+        Ok(())
+    }
 }
 
-/// Serializes a value to a vector and add a CBOR self-describe tag.
-pub fn to_vec_sd<T: Serialize>(value: &T) -> Result<Vec<u8>> {
-    let mut vec = Vec::new();
-    to_writer_sd(&mut vec, value)?;
-    Ok(vec)
+impl<'a, W> ser::SerializeStruct for StructSerializer<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.serialize_field_inner(key, value)
+    }
+
+    #[inline]
+    fn skip_field(&mut self, key: &'static str) -> Result<()> {
+        self.skip_field_inner(key)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        Ok(())
+    }
 }
 
-/// Serializes a value without names to a vector.
-pub fn to_vec_packed<T: Serialize>(value: &T) -> Result<Vec<u8>> {
-    let mut vec = Vec::new();
-    to_writer_packed(&mut vec, value)?;
-    Ok(vec)
-}
-/// Serializes a value without names to a vector and add a CBOR self-describe tag.
-pub fn to_vec_packed_sd<T: Serialize>(value: &T) -> Result<Vec<u8>> {
-    let mut vec = Vec::new();
-    to_writer_packed_sd(&mut vec, value)?;
-    Ok(vec)
+impl<'a, W> ser::SerializeStructVariant for StructSerializer<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.serialize_field_inner(key, value)
+    }
+
+    #[inline]
+    fn skip_field(&mut self, key: &'static str) -> Result<()> {
+        self.skip_field_inner(key)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        Ok(())
+    }
 }
 
+#[doc(hidden)]
+pub struct CollectionSerializer<'a, W: 'a> {
+    ser: &'a mut Serializer<W>,
+    needs_eof: bool,
+}
+
+impl<'a, W> CollectionSerializer<'a, W>
+where
+    W: io::Write,
+{
+    #[inline]
+    fn end_inner(self) -> Result<()> {
+        if self.needs_eof {
+            self.ser.writer.write_all(&[0xff]).map_err(Error::io)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a, W> ser::SerializeSeq for CollectionSerializer<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(&mut *self.ser)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        self.end_inner()
+    }
+}
+
+impl<'a, W> ser::SerializeMap for CollectionSerializer<'a, W>
+where
+    W: io::Write,
+{
+    type Ok = ();
+    type Error = Error;
+
+    #[inline]
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        key.serialize(&mut *self.ser)
+    }
+
+    #[inline]
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(&mut *self.ser)
+    }
+
+    #[inline]
+    fn end(self) -> Result<()> {
+        self.end_inner()
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -215,7 +215,8 @@ impl Value {
 impl<'de> de::Deserialize<'de> for Value {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
-        where D: de::Deserializer<'de>
+    where
+        D: de::Deserializer<'de>,
     {
         struct ValueVisitor;
 
@@ -228,69 +229,79 @@ impl<'de> de::Deserialize<'de> for Value {
 
             #[inline]
             fn visit_str<E>(self, value: &str) -> Result<Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_string(String::from(value))
             }
 
             #[inline]
             fn visit_string<E>(self, value: String) -> Result<Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::String(value))
             }
             #[inline]
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_byte_buf(v.to_owned())
             }
 
             #[inline]
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::Bytes(v))
             }
 
             #[inline]
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::U64(v))
             }
 
             #[inline]
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::I64(v))
             }
 
             #[inline]
             fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::Bool(v))
             }
 
             #[inline]
             fn visit_none<E>(self) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_unit()
             }
 
             #[inline]
             fn visit_unit<E>(self) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::Null)
             }
 
             #[inline]
             fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-                where V: de::SeqAccess<'de>
+            where
+                V: de::SeqAccess<'de>,
             {
                 let mut vec = Vec::new();
 
@@ -303,7 +314,8 @@ impl<'de> de::Deserialize<'de> for Value {
 
             #[inline]
             fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
-                where V: de::MapAccess<'de>
+            where
+                V: de::MapAccess<'de>,
             {
                 let mut values = BTreeMap::new();
 
@@ -316,7 +328,8 @@ impl<'de> de::Deserialize<'de> for Value {
 
             #[inline]
             fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(Value::F64(v))
             }
@@ -326,11 +339,11 @@ impl<'de> de::Deserialize<'de> for Value {
     }
 }
 
-
 impl ser::Serialize for Value {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: ser::Serializer
+    where
+        S: ser::Serializer,
     {
         match *self {
             Value::U64(v) => serializer.serialize_u64(v),
@@ -464,7 +477,8 @@ impl ObjectKey {
 impl<'de> de::Deserialize<'de> for ObjectKey {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<ObjectKey, D::Error>
-        where D: de::Deserializer<'de>
+    where
+        D: de::Deserializer<'de>,
     {
         struct ObjectKeyVisitor;
 
@@ -477,62 +491,71 @@ impl<'de> de::Deserialize<'de> for ObjectKey {
 
             #[inline]
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_string(String::from(value))
             }
 
             #[inline]
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::String(value))
             }
             #[inline]
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_byte_buf(v.to_owned())
             }
 
             #[inline]
             fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::Bytes(v))
             }
 
             #[inline]
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::Integer(v as i64))
             }
 
             #[inline]
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::Integer(v))
             }
 
             #[inline]
             fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::Bool(v))
             }
 
             #[inline]
             fn visit_none<E>(self) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 self.visit_unit()
             }
 
             #[inline]
             fn visit_unit<E>(self) -> Result<Self::Value, E>
-                where E: de::Error
+            where
+                E: de::Error,
             {
                 Ok(ObjectKey::Null)
             }
@@ -545,7 +568,8 @@ impl<'de> de::Deserialize<'de> for ObjectKey {
 impl ser::Serialize for ObjectKey {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: ser::Serializer
+    where
+        S: ser::Serializer,
     {
         match *self {
             ObjectKey::Integer(v) => serializer.serialize_i64(v),

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -102,6 +102,23 @@ testcase!(test_person_struct,
     "a3646e616d656c477261636520486f707065726d796561725f6f665f62697274681907726a70726f66657373696f6e72636f6d707574657220736369656e74697374");
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
+struct OptionalPerson {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    year_of_birth: Option<u16>,
+    profession: Option<String>,
+}
+
+testcase!(test_optional_person_struct,
+    OptionalPerson,
+    OptionalPerson {
+        name: "Grace Hopper".to_string(),
+        year_of_birth: None,
+        profession: Some("computer scientist".to_string()),
+    },
+    "a2646e616d656c477261636520486f707065726a70726f66657373696f6e72636f6d707574657220736369656e74697374");
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 enum Color {
     Red,
     Blue,


### PR DESCRIPTION
This commit consists of a rewrite of basically all of the serialization
and deserialization logic. The API and internals are based heavily off
of serde_json, in particular, the error type and support for borrowed
deserialization. The deserialization logic is now based off of the tag
byte lookup table described in appendix B of RFC 7049. It's a bit more
verbose, but compiles down to a jump table so there should be some
decent performance benefits in deserialization. It should also resolve
some longstanding correctness issues with deserialization of indefinite
length maps and sequences. The packed encoding can now properly handle
conditionally skipped fields and doesn't need special logic on the
deserialization side due to new serde features.

Closes #37
Closes #36
Closes #32
Closes #31