### PR TITLE
Set Serializer is_human_readable to false.

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -453,6 +453,10 @@ where
         self.serialize_unit_variant(name, variant_index, variant)?;
         self.serialize_struct(name, len)
     }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 impl<'a, W> ser::SerializeTuple for &'a mut Serializer<W>

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -91,3 +91,13 @@ fn test_self_describing() {
     }
     assert_eq!(vec, b"\xd9\xd9\xf7\x09");
 }
+
+#[test]
+fn test_ip_addr() {
+    use std::net::Ipv4Addr;
+
+    let addr = Ipv4Addr::new(8, 8, 8, 8);
+    let vec = to_vec(&addr).unwrap();
+    println!("{:?}", vec);
+    assert_eq!(vec.len(), 5);
+}


### PR DESCRIPTION
Closes #51

BREAKING CHANGE: This results in a different serialization
for common types e.g. Ipv4Addr.