### PR TITLE
Add support for CBOR semantic tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ extern crate byteorder;
 extern crate serde;
 
 mod read;
+pub mod tagged;
 pub mod de;
 pub mod error;
 pub mod ser;

--- a/src/tagged.rs
+++ b/src/tagged.rs
@@ -1,0 +1,55 @@
+//! Helper function for emitting CBOR tags
+
+use serde::ser::{Serialize, SerializeTupleStruct, Serializer};
+use error;
+use std::fmt;
+
+pub(crate) static CBOR_NO_LENGTH_FIELD: &'static str = "__CBOR_NO_LENGTH_FIELD";
+
+#[derive(Copy, Clone)]
+pub(crate) struct CborTag(pub u64);
+
+impl Serialize for CborTag {
+    /// This function is never actually called, but only used for pointer comparisons
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        panic!("BUG: Should never be called");
+    }
+}
+
+impl fmt::Display for CborTag {
+    /// This function is never actually called, but only used for pointer comparisons
+    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+        panic!("BUG: Should never be called");
+    }
+}
+
+#[inline]
+/// Serializes a value like normally, but if the serializer is the CBOR serializer, it will also
+/// emit the tag value.
+pub fn serialize_tagged<S, T>(tag: u64, value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    let s_fn = S::Error::custom::<CborTag>;
+    let cbor_fn = error::Error::custom::<CborTag>;
+    if s_fn as usize == cbor_fn as usize {
+        // We should only get in here if we are in a serializer that uses the error type from this
+        // crate. This should never happen for any other serializers.
+        //
+        // However if it does, then we will emit a tuple struct with name
+        // __CBOR_NO_LENGTH_FIELD. For our serializer this triggers the behavior of outputting the
+        // CBOR tag, but other in other serializers this is likely to panic.
+        let mut tuple_serializer = serializer.serialize_tuple_struct(CBOR_NO_LENGTH_FIELD, 2)?;
+        tuple_serializer.serialize_field(&CborTag(tag))?;
+        tuple_serializer.serialize_field(&value)?;
+        tuple_serializer.end()
+    } else {
+        value.serialize(serializer)
+    }
+}


### PR DESCRIPTION
Hi,

I've tried to add support for CBOR tags. It is **pretty** hacky and feel free to reject it if you don't think this is the right approach. I'm not actually convinced that this is a good idea at all, but I wanted to try hacking it in. And now that I am done, I might as well ask for your opinion.

If rust-lang/rust#41875 is ever implemented, this code should become a lot more safe and easier to read. In the meantime, here we are.