### PR TITLE
Fix roundtrip (de)serialization

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -663,6 +663,11 @@ where
         }
     }
 
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string unit
         unit_struct seq tuple tuple_struct map struct identifier ignored_any

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -454,6 +454,7 @@ where
         self.serialize_struct(name, len)
     }
 
+    #[inline]
     fn is_human_readable(&self) -> bool {
         false
     }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -100,4 +100,6 @@ fn test_ip_addr() {
     let vec = to_vec(&addr).unwrap();
     println!("{:?}", vec);
     assert_eq!(vec.len(), 5);
+    let test_addr: Ipv4Addr = from_slice(&vec).unwrap();
+    assert_eq!(addr, test_addr);
 }


### PR DESCRIPTION
Add failing test and fix #57 by setting Deserializer's `is_human_readable` to `false` to match `Serializer`.