### PR TITLE
implement from_value() to convert Value to any type implementing Deserialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,4 +144,4 @@ pub use de::{from_slice, from_reader, Deserializer};
 #[doc(inline)]
 pub use ser::{to_writer, to_vec, Serializer};
 #[doc(inline)]
-pub use value::{Value, ObjectKey, to_value};
+pub use value::{Value, ObjectKey, to_value, from_value};

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -3,5 +3,5 @@
 pub mod value;
 pub mod ser;
 
-pub use self::value::{ObjectKey, Value};
+pub use self::value::{ObjectKey, Value, from_value};
 pub use self::ser::to_value;

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -632,3 +632,16 @@ impl_from!(Value, Array, Vec<Value>);
 impl_from!(Value, Object, BTreeMap<ObjectKey, Value>);
 impl_from!(Value, F64, f64);
 impl_from!(Value, Bool, bool);
+
+/// Convert a `serde_cbor::Value` into a type `T`
+pub fn from_value<T>(value: Value) -> Result<T, ::error::Error>
+where
+    T: de::DeserializeOwned,
+{
+    // TODO implement in a way that doesn't require
+    // roundtrip through buffer (i.e. by implementing
+    // `serde::de::Deserializer` for `Value` and then doing
+    // `T::deserialize(value)`).
+    let buf = ::to_vec(&value)?;
+    ::from_slice(buf.as_slice())
+}


### PR DESCRIPTION
Hi, this implements `fn from_value<T: DeserializeOwned>(value: Value) -> Result<T, Error>` which takes a `serde_cbor::Value` and converts it to type `T`. This is much like the equivalent function in serde_json.

The implementation is very simple but also suboptimal - it serializes `serde_cbor::Value` and then deserializes into type `T`. I thought I would propose this implementation as a start, because I did not dig in enough to check if there was already substantial machinery in place to perform this conversion directly or if an implementation of `serde::de::Deserializer` for `serde_cbor::Value` would need to be written from scratch so that `T::deserialize(value)` would directly work.