### PR TITLE
Adds the option to encode enums as 1-key maps.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,6 @@ pub mod value;
 #[doc(inline)]
 pub use de::{from_slice, from_reader, Deserializer, StreamDeserializer};
 #[doc(inline)]
-pub use ser::{to_writer, to_vec, Serializer};
+pub use ser::{to_writer, to_vec, to_vec_with_options, Serializer, SerializerOptions};
 #[doc(inline)]
 pub use value::{Value, ObjectKey, to_value, from_value};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -52,27 +52,6 @@ where
     value.serialize(&mut ser)
 }
 
-/// Serializes a value without names to a writer.
-pub fn to_writer_with_options<W, T>(mut writer: &mut W, value: &T, options: &SerializerOptions) -> Result<()>
-where
-    W: io::Write,
-    T: ser::Serialize,
-{
-    let mut ser = Serializer::new_with_options(&mut writer, options);
-    value.serialize(&mut ser)
-}
-
-/// Serializes a value without names to a writer and adds a CBOR self-describe tag.
-pub fn to_writer_with_options_sd<W, T>(mut writer: &mut W, value: &T, options: &SerializerOptions) -> Result<()>
-where
-    W: io::Write,
-    T: ser::Serialize,
-{
-    let mut ser = Serializer::new_with_options(&mut writer, options);
-    ser.self_describe()?;
-    value.serialize(&mut ser)
-}
-
 /// Serializes a value to a vector.
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
@@ -124,7 +103,10 @@ where
     T: ser::Serialize,
 {
     let mut vec = Vec::new();
-    to_writer_with_options(&mut vec, value, options)?;
+    {
+        let mut ser = Serializer::new_with_options(&mut vec, options);
+        value.serialize(&mut ser)?;
+    }
     Ok(vec)
 }
 
@@ -134,7 +116,11 @@ where
     T: ser::Serialize,
 {
     let mut vec = Vec::new();
-    to_writer_with_options_sd(&mut vec, value, options)?;
+    {
+        let mut ser = Serializer::new_with_options(&mut vec, options);
+        ser.self_describe()?;
+        value.serialize(&mut ser)?;
+    }
     Ok(vec)
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -105,20 +105,9 @@ where
     let mut vec = Vec::new();
     {
         let mut ser = Serializer::new_with_options(&mut vec, options);
-        value.serialize(&mut ser)?;
-    }
-    Ok(vec)
-}
-
-/// Serializes a value to a vector and adds a CBOR self-describe tag.
-pub fn to_vec_with_options_sd<T>(value: &T, options: &SerializerOptions) -> Result<Vec<u8>>
-where
-    T: ser::Serialize,
-{
-    let mut vec = Vec::new();
-    {
-        let mut ser = Serializer::new_with_options(&mut vec, options);
-        ser.self_describe()?;
+        if options.self_describe {
+            ser.self_describe()?;
+        }
         value.serialize(&mut ser)?;
     }
     Ok(vec)
@@ -169,6 +158,15 @@ pub struct SerializerOptions {
     pub packed: bool,
     /// When set, enums are encoded as maps rather than arrays.
     pub enum_as_map: bool,
+    /// When set, `to_vec` will prepend the CBOR self-describe tag.
+    pub self_describe: bool,
+}
+
+impl SerializerOptions {
+    /// Serializes a value to a vector.
+    pub fn to_vec<T: ser::Serialize>(&self, value: &T) -> Result<Vec<u8>> {
+        to_vec_with_options(value, self)
+    }
 }
 
 /// A structure for serializing Rust values to CBOR.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -218,6 +218,7 @@ where
         let mut s = Serializer {
             writer: buf,
             packed: self.packed,
+            enum_as_map: self.enum_as_map,
         };
         v.serialize(&mut s)?;
         Ok(s.writer)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -568,7 +568,11 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<StructSerializer<'a, W>> {
-        self.writer.write_all(&[4 << 5 | 2]).map_err(Error::io)?;
+        if self.enum_as_map {
+            self.write_u64(5, 1u64)?;
+        } else {
+            self.writer.write_all(&[4 << 5 | 2]).map_err(Error::io)?;
+        }
         self.serialize_unit_variant(name, variant_index, variant)?;
         self.serialize_struct(name, len)
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -139,13 +139,49 @@ where
 }
 
 /// Options for a CBOR serializer.
+///
+/// The `enum_as_map` option determines how enums are encoded.
+///
+/// This makes no difference when encoding and decoding enums using
+/// this crate, but it shows up when decoding to a `Value` or decoding
+/// in other languages.
+///
+/// With enum_as_map true, the encoding scheme matches the default encoding
+/// scheme used by `serde_json`.
+///
+/// # Examples
+///
+/// Given the following enum
+/// ```
+/// enum Enum {
+///     Unit,
+///     NewType(i32),
+///     Tuple(String, bool),
+///     Struct{ x: i32, y: i32 },
+/// }
+/// ```
+/// we will give the `Value` with the same encoding for each case using
+/// JSON notation.
+///
+/// ## Default encodings
+///
+/// * `Enum::Unit` encodes as `"Unit"`
+/// * `Enum::NewType(10)` encodes as `["NewType", 10]`
+/// * `Enum::Tuple("x", true)` encodes as `["Tuple", "x", true]`
+/// * `Enum::Struct{ x: 5, y: -5 }` encodes as `["Struct", {"x": 5, "y": -5}]`
+///
+/// ## Encodings with enum_as_map true
+///
+/// * `Enum::Unit` encodes as `"Unit"`
+/// * `Enum::NewType(10)` encodes as `{"NewType": 10}`
+/// * `Enum::Tuple("x", true)` encodes as `{"Tuple": ["x", true]}`
+/// * `Enum::Struct{ x: 5, y: -5 }` encodes as `{"Struct": {"x": 5, "y": -5}}`
+#[derive(Default)]
 pub struct SerializerOptions {
-    /// Struct fields and enum variants are identified by their numeric indices rather than names
+    /// When set, struct fields and enum variants are identified by their numeric indices rather than names
     /// to save space.
     pub packed: bool,
-    /// When enum_as_map is set, enums are encoded as maps rather than arrays.
-    /// This makes no difference when decoding to an enum value but it shows
-    /// up when decoding to a `Value` or decoding in other languages.
+    /// When set, enums are encoded as maps rather than arrays.
     pub enum_as_map: bool,
 }
 

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 
 use std::collections::BTreeMap;
 
-use serde_cbor::{from_slice, to_vec, to_vec_with_options, Value, ObjectKey};
+use serde_cbor::{from_slice, to_vec, Value, ObjectKey};
 
 #[derive(Debug,Serialize,Deserialize,PartialEq,Eq)]
 enum Enum {
@@ -135,28 +135,28 @@ fn test_enum_as_map() {
     assert_eq!(point_s, point_vec_s);
 
     // enum_as_map matches serde_json's default serialization for enums.
-    let opts = serde_cbor::SerializerOptions{ packed: false, enum_as_map: true };
+    let opts = serde_cbor::SerializerOptions{ enum_as_map: true, ..Default::default() };
 
     // unit variants still serialize like bare strings
-    let empty_s = to_vec_with_options(&Bar::Empty, &opts).unwrap();
+    let empty_s = opts.to_vec(&Bar::Empty).unwrap();
     assert_eq!(empty_s, empty_str_s);
 
     // 1-element tuple variants serialize like {"<variant>": value}
-    let number_s = to_vec_with_options(&Bar::Number(42), &opts).unwrap();
+    let number_s = opts.to_vec(&Bar::Number(42)).unwrap();
     let mut number_map = BTreeMap::new();
     number_map.insert("Number", 42);
     let number_map_s = to_vec(&number_map).unwrap();
     assert_eq!(number_s, number_map_s);
 
     // multi-element tuple variants serialize like {"<variant>": [values..]}
-    let flag_s = to_vec_with_options(&Bar::Flag("foo".to_string(), true), &opts).unwrap();
+    let flag_s = opts.to_vec(&Bar::Flag("foo".to_string(), true)).unwrap();
     let mut flag_map = BTreeMap::new();
     flag_map.insert("Flag", vec![Value::String("foo".to_string()), Value::Bool(true)]);
     let flag_map_s = to_vec(&flag_map).unwrap();
     assert_eq!(flag_s, flag_map_s);
 
     // struct-variants serialize like {"<variant>", {struct..}}
-    let point_s = to_vec_with_options(&Bar::Point{ x: 5, y: -5}, &opts).unwrap();
+    let point_s = opts.to_vec(&Bar::Point{ x: 5, y: -5}).unwrap();
     let mut point_map = BTreeMap::new();
     point_map.insert("Point", Value::Object(struct_map));
     let point_map_s = to_vec(&point_map).unwrap();

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -135,6 +135,10 @@ fn test_self_describing() {
         serializer.serialize_u64(9).unwrap();
     }
     assert_eq!(vec, b"\xd9\xd9\xf7\x09");
+
+    let sd = ser::SerializerOptions{ self_describe: true, ..Default::default() };
+    let vec = sd.to_vec(&9).unwrap();
+    assert_eq!(vec, b"\xd9\xd9\xf7\x09");
 }
 
 #[test]


### PR DESCRIPTION
Since enums are part of the Rust language but not part of the CBOR or JSON spec, each serializer has to make a choice how to encode them. 

serde_cbor chose `["Variant", items..]` while serde_json chose `{"Variant": item}` or `{"Variant": [items..]}`. Although this is immaterial when passing data between Rust programs, it becomes visible if `Values` are used, or when data is passed between Rust and other languages.

This turned out to be a problem for me when I tried to migrate a communicating pair of Python and Rust programs from JSON to CBOR, as assumptions about the encoding of enums had already become buried throughout the Python code.

This pull request adds the option (default false) to encode enums in the serde_json way and adds support for automatically decoding enums from either encoding.
