### PR TITLE
Replace deprecated as_bits with to_bits

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -301,7 +301,7 @@ where
             self.writer.write_all(&[0xf9, 0x7e, 0x00])
         } else if f32::from(f16::from_f32(value)) == value {
             let mut buf = [0xf9, 0, 0];
-            BigEndian::write_u16(&mut buf[1..], f16::from_f32(value).as_bits());
+            BigEndian::write_u16(&mut buf[1..], f16::from_f32(value).to_bits());
             self.writer.write_all(&buf)
         } else {
             let mut buf = [0xfa, 0, 0, 0, 0];


### PR DESCRIPTION
half-rs renamed `f16::as_bits` to `f16::to_bits` in v1.2.0 in this [commit](https://github.com/starkat99/half-rs/commit/4da87b20e6146f3b19902c52c6a85ea7dbacb311). `as_bits` has been deprecated.

Signed-off-by: dingelish <dingelish@gmail.com>