### PR TITLE
IoReader enhancements

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -244,6 +244,20 @@ fn stream_deserializer_eof() {
 }
 
 #[test]
+fn stream_deserializer_eof_in_indefinite() {
+    let slice = b"\x7f\x65Mary \x64Had \x62a \x67Little \x64Lamb\xff";
+    let indices: &[usize] = &[
+        2, // announcement but no data
+        10, // mid-buffer EOF
+        12, // neither new element nor end marker
+    ];
+    for end_of_slice in indices {
+        let mut it = Deserializer::from_slice(&slice[..*end_of_slice]).into_iter::<Value>();
+        assert!(it.next().unwrap().unwrap_err().is_eof());
+    }
+}
+
+#[test]
 fn test_large_bytes() {
     let expected = (0..2 * 1024 * 1024).map(|i| (i * 7) as u8).collect::<Vec<_>>();
     let expected = ByteBuf::from(expected);

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -114,6 +114,16 @@ fn test_indefinite_byte_string() {
 }
 
 #[test]
+fn test_multiple_indefinite_strings() {
+    // This assures that buffer rewinding in infinite buffers works as intended.
+    let value: error::Result<Value> = de::from_slice(b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff");
+    assert_eq!(value.unwrap(), Value::Array(vec![
+        Value::String("Mary Had a Little Lamb".to_owned()),
+        Value::Bytes(b"\x01#Eg".to_vec())
+        ]));
+}
+
+#[test]
 fn test_float() {
     let value: error::Result<Value> = de::from_slice(b"\xfa\x47\xc3\x50\x00");
     assert_eq!(value.unwrap(), Value::F64(100000.0));

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -103,7 +103,7 @@ fn test_indefinite_list() {
 
 #[test]
 fn test_indefinite_string() {
-    let value: error::Result<Value> = de::from_slice(b"\x7f\x65Mary \x64Had \x62a \x67Little \x64Lamb\xff");
+    let value: error::Result<Value> = de::from_slice(b"\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff");
     assert_eq!(value.unwrap(), Value::String("Mary Had a Little Lamb".to_owned()));
 }
 
@@ -116,7 +116,7 @@ fn test_indefinite_byte_string() {
 #[test]
 fn test_multiple_indefinite_strings() {
     // This assures that buffer rewinding in infinite buffers works as intended.
-    let value: error::Result<Value> = de::from_slice(b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff");
+    let value: error::Result<Value> = de::from_slice(b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff");
     assert_eq!(value.unwrap(), Value::Array(vec![
         Value::String("Mary Had a Little Lamb".to_owned()),
         Value::Bytes(b"\x01#Eg".to_vec())
@@ -245,7 +245,7 @@ fn stream_deserializer_eof() {
 
 #[test]
 fn stream_deserializer_eof_in_indefinite() {
-    let slice = b"\x7f\x65Mary \x64Had \x62a \x67Little \x64Lamb\xff";
+    let slice = b"\x7f\x65Mary \x64Had \x62a \x60\x67Little \x60\x64Lamb\xff";
     let indices: &[usize] = &[
         2, // announcement but no data
         10, // mid-buffer EOF


### PR DESCRIPTION
These patches are by-catch of my work on #79, but should can stand on their own; in summary:

* Add more test cases for indefinite length strings (to catch what I think would be the most likely to go wrong with the following changes)
* Simplify `.read_into()` by using a provided method of the Read trait that does mostly the same (what's left is EOF error wrapping)
* In `.read()`, use [`Read::take()`](https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.take) (with [`Read::by_ref()`](https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.by_ref) as in its example to keep the original reader in place) to directly put the read data into the buffer vector without zeroing out a fresh area before

I haven't run any benchmarks on them, but I expect the read_into change to result in the same machine under optimization, and the read change to negligibly remove a cheap memory clearing -- but the former reduces code complexity, and the latter uses the vec's length cursor (which is available anyway) to more clearly express which portion of the scratch buffer is usable.