### PR TITLE
[WIP] Move scratch buffers into readers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.18.0
+  - 1.26.0
   - stable
   - beta
   - nightly

--- a/src/de.rs
+++ b/src/de.rs
@@ -188,7 +188,9 @@ where
         }
     }
 
-    fn parse_indefinite_bytes(&mut self) -> Result<&[u8]> {
+    fn parse_indefinite_bytes<V>(&mut self, visitor: V) -> Result<V::Value> where
+        V: de::Visitor<'de>,
+    {
         self.read.clear_buffer();
         loop {
             let byte = self.parse_u8()?;
@@ -211,7 +213,10 @@ where
             self.read.read_to_buffer(len)?;
         }
 
-        Ok(self.read.view_buffer())
+        match self.read.view_buffer() {
+            EitherLifetime::Long(buf) => visitor.visit_borrowed_bytes(buf),
+            EitherLifetime::Short(buf) => visitor.visit_bytes(buf),
+        }
     }
 
     fn convert_str<'a>(buf: &'a [u8], buf_end_offset: u64) -> Result<&'a str> {
@@ -242,7 +247,9 @@ where
         }
     }
 
-    fn parse_indefinite_str(&mut self) -> Result<&str> {
+    fn parse_indefinite_str<V>(&mut self, visitor: V) -> Result<V::Value> where
+        V: de::Visitor<'de>,
+    {
         self.read.clear_buffer();
         loop {
             let byte = self.parse_u8()?;
@@ -266,7 +273,16 @@ where
         }
 
         let offset = self.read.offset();
-        Self::convert_str(self.read.view_buffer(), offset)
+        match self.read.view_buffer() {
+            EitherLifetime::Long(buf) => {
+                let s = Self::convert_str(buf, offset)?;
+                visitor.visit_borrowed_str(s)
+            }
+            EitherLifetime::Short(buf) => {
+                let s = Self::convert_str(buf, offset)?;
+                visitor.visit_str(s)
+            }
+        }
     }
 
     fn recursion_checked<F, T>(&mut self, f: F) -> Result<T>
@@ -461,8 +477,7 @@ where
             }
             0x5c...0x5e => Err(self.error(ErrorCode::UnassignedCode)),
             0x5f => {
-                let bytes = self.parse_indefinite_bytes()?;
-                visitor.visit_bytes(bytes)
+                self.parse_indefinite_bytes(visitor)
             }
 
             // Major type 3: a text string
@@ -488,8 +503,7 @@ where
             }
             0x7c...0x7e => Err(self.error(ErrorCode::UnassignedCode)),
             0x7f => {
-                let s = self.parse_indefinite_str()?;
-                visitor.visit_str(s)
+                self.parse_indefinite_str(visitor)
             }
 
             // Major type 4: an array of data items

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub mod ser;
 pub mod value;
 
 #[doc(inline)]
-pub use de::{from_slice, from_reader, Deserializer, StreamDeserializer};
+pub use de::{from_slice, from_mut_slice, from_reader, Deserializer, StreamDeserializer};
 #[doc(inline)]
 pub use ser::{to_writer, to_vec, Serializer};
 #[doc(inline)]

--- a/src/read.rs
+++ b/src/read.rs
@@ -302,3 +302,132 @@ impl<'a> Read<'a> for SliceRead<'a> {
         self.index as u64
     }
 }
+
+/// A CBOR input source that reads from a slice of bytes, and can move data around internally to
+/// reassemble indefinite strings without the need of an allocated scratch buffer.
+///
+/// This is implemented using unsafe code, which relies on the implementation not to mutate the
+/// slice wherever immutable references have been handed out; that position is tracked in
+/// buffer_end.
+pub struct MutSliceRead<'a> {
+    /// A complete view of the reader's data. It is promised that bytes before buffer_end are not
+    /// mutated any more.
+    slice: &'a mut [u8],
+    /// Read cursor position in slice
+    index: usize,
+    /// Index when clear() was last called
+    buffer_start: usize,
+    /// End of the buffer area that contains all bytes read_into_buffer. Doubles as end of
+    /// immutability guarantee.
+    buffer_end: usize,
+}
+
+impl<'a> MutSliceRead<'a> {
+    /// Creates a CBOR input source to read from a slice of bytes.
+    pub fn new(slice: &'a mut [u8]) -> MutSliceRead<'a> {
+        MutSliceRead {
+            slice,
+            index: 0,
+            buffer_start: 0,
+            buffer_end: 0,
+        }
+    }
+
+    fn end(&self, n: usize) -> Result<usize> {
+        match self.index.checked_add(n) {
+            Some(end) if end <= self.slice.len() => Ok(end),
+            _ => {
+                Err(Error::syntax(
+                    ErrorCode::EofWhileParsingValue,
+                    self.slice.len() as u64,
+                ))
+            }
+        }
+    }
+}
+
+impl<'a> private::Sealed for MutSliceRead<'a> {}
+
+impl<'a> Read<'a> for MutSliceRead<'a> {
+    #[inline]
+    fn next(&mut self) -> io::Result<Option<u8>> {
+        // This is duplicated from SliceRead, can that be eased?
+        Ok(if self.index < self.slice.len() {
+            let ch = self.slice[self.index];
+            self.index += 1;
+            Some(ch)
+        } else {
+            None
+        })
+    }
+
+    #[inline]
+    fn peek(&mut self) -> io::Result<Option<u8>> {
+        // This is duplicated from SliceRead, can that be eased?
+        Ok(if self.index < self.slice.len() {
+            Some(self.slice[self.index])
+        } else {
+            None
+        })
+    }
+
+    fn clear_buffer<'b>(&'b mut self) {
+        self.buffer_start = self.index;
+        self.buffer_end = self.index;
+    }
+
+    fn read_to_buffer(&mut self, n: usize) -> Result<()> {
+        let end = self.end(n)?;
+        assert!(self.buffer_end <= self.index, "MutSliceRead invariant violated: scratch buffer exceeds index");
+        self.slice[self.buffer_end..end].rotate_left(self.index - self.buffer_end);
+        self.buffer_end += n;
+        self.index = end;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn read(&mut self, n: usize) -> Result<Reference<'a>> {
+        let end = self.end(n)?;
+        let slice = &self.slice[self.index..end];
+        self.index = end;
+
+        // Not technically required to keep track of things under realistic (ie. either read
+        // or clear_buffer+n*read_to_buffer is called) conditions, but given we don't want to rely
+        // on these condition to maintain safety, this updates the immutability contract of the
+        // slice.
+        self.buffer_start = self.index;
+        self.buffer_end = self.index;
+
+        // Unsafe: Extending the lifetime from during-the-function to 'a ("for as long as
+        // MutSliceRead is in mutable control of the data"), which is OK because MutSliceRead
+        // promises to never mutate data before buffer_end.
+        let extended_result = unsafe { &*(slice as *const _) };
+
+        Ok(Reference::Borrowed(extended_result))
+    }
+
+    fn view_buffer<'b>(&'b self) -> &'b [u8] {
+        // No unsafe tricks necessary here -- we could give out a longer lifetime, because to us
+        // all data in the buffer is immutable, but the Vec<u8> based readers can't do that.
+        &self.slice[self.buffer_start..self.buffer_end]
+    }
+
+    #[inline]
+    fn read_into(&mut self, buf: &mut [u8]) -> Result<()> {
+        // This is duplicated from SliceRead, can that be eased?
+        let end = self.end(buf.len())?;
+        buf.copy_from_slice(&self.slice[self.index..end]);
+        self.index = end;
+        Ok(())
+    }
+
+    #[inline]
+    fn discard(&mut self) {
+        self.index += 1;
+    }
+
+    fn offset(&self) -> u64 {
+        self.index as u64
+    }
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -117,10 +117,16 @@ where
         // defend against malicious input pretending to be huge strings by limiting growth
         scratch.reserve(cmp::min(n, 16 * 1024));
 
+        if n == 0 {
+            return Ok(Reference::Borrowed(&[]));
+        }
+
         if let Some(ch) = self.ch.take() {
             scratch.push(ch);
             n -= 1;
         }
+
+        // n == 0 is OK here and needs no further special treatment
 
         let transfer_result = {
             // Prepare for take() (which consumes its reader) by creating a reference adaptor

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -115,8 +115,12 @@ fn test_indefinite_byte_string() {
 
 #[test]
 fn test_multiple_indefinite_strings() {
+    let input = b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff";
+    _test_multiple_indefinite_strings(de::from_slice(input));
+    _test_multiple_indefinite_strings(de::from_mut_slice(input.to_vec().as_mut()));
+}
+fn _test_multiple_indefinite_strings(value: error::Result<Value>) {
     // This assures that buffer rewinding in infinite buffers works as intended.
-    let value: error::Result<Value> = de::from_slice(b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff");
     assert_eq!(value.unwrap(), Value::Array(vec![
         Value::String("Mary Had a Little Lamb".to_owned()),
         Value::Bytes(b"\x01#Eg".to_vec())
@@ -253,6 +257,10 @@ fn stream_deserializer_eof_in_indefinite() {
     ];
     for end_of_slice in indices {
         let mut it = Deserializer::from_slice(&slice[..*end_of_slice]).into_iter::<Value>();
+        assert!(it.next().unwrap().unwrap_err().is_eof());
+
+        let mut mutcopy = slice[..*end_of_slice].to_vec();
+        let mut it = Deserializer::from_mut_slice(mutcopy.as_mut()).into_iter::<Value>();
         assert!(it.next().unwrap().unwrap_err().is_eof());
     }
 }


### PR DESCRIPTION
This PR describes an idea of how to one might continue after #80, and one answer to the question of whether `scratch_offset` can go away there.

The meat of this PR is 86a51c3762d7daabc214f3621e0d63ed8cd91b4f, 18e254623a39c0c4b0fb69f13181a18f37c9ea70 and 9e123f7cdb4f9492e922c6af72fe314dc3f7b148 (there's a few before because I can't create a PR in github that's based on another PR) which may also make sense to read as a cumulative diff; between them, there is 6fa55802f6a1ae7ce34291ce6aa107a4d6981476 that describes a possible application, and then interfacing and test coverage.

What the patch does is to move the scratch buffer from the deserializer to the the Read trait; each reader can manage a buffer as it seems fit. The Read trait methods change a bit:
* read() now always returns a slice, but while earlier it gave an Enum telling you to either take the 'de long-lived result or to have a short-lived peek into the buffer, it now returns an Enum that always contains a slice but has variable lifetimes.
* For gathering a long slice, the's now the `clear_buffer()` / `read_to_buffer()` / `view_buffer` trio, which exposes functionality previously managed by the decoder's buf (`buf.clear()`, `.read(n, buf)`, `buf.as_ref()`) -- that allows implementing MutSliceRead to manage its own scratch buffer by shuffling data around in its slice. For consistency, `.view_buffer()` returns the same enum as `.read()`. (This allows indefinite strings from a MutSliceRead to go the `visit_borrowed_bytes` route).

The rationale for these changes is twofold:
* They (or at least the first part thereof in 86a51c3762d7daabc214f3621e0d63ed8cd91b4f) allow implementing a MutSliceRead, and thus decoding any CBOR in a no_std (and not even alloc) environment.
* They reduce the `#[cfg(...)]` gating that'd be necessary to make serde_cbor ready for no_std because the individual readers now can take the cfg decisions. (And even there it's fewer places, as the Read trait can stay the same, IoRead needs to be gated anyway, and only SliceRead needs to decide whether it can do `.read_to_buffer()` or not.