### PR TITLE
no_std: more preparatory steps

### DIFF
--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,8 +1,8 @@
 // NOTE: This file should be kept in sync with README.md
 
+use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use std::fs::File;
-use serde_derive::{Deserialize, Serialize};
 
 // Types annotated with `Serialize` can be stored as CBOR.
 // To be able to load them again add `Deserialize`.

--- a/src/de.rs
+++ b/src/de.rs
@@ -239,7 +239,7 @@ where
             self.read.read_to_buffer(len)?;
         }
 
-        match self.read.view_buffer() {
+        match self.read.take_buffer() {
             EitherLifetime::Long(buf) => visitor.visit_borrowed_bytes(buf),
             EitherLifetime::Short(buf) => visitor.visit_bytes(buf),
         }
@@ -307,7 +307,7 @@ where
         }
 
         let offset = self.read.offset();
-        match self.read.view_buffer() {
+        match self.read.take_buffer() {
             EitherLifetime::Long(buf) => {
                 let s = Self::convert_str(buf, offset)?;
                 visitor.visit_borrowed_str(s)

--- a/src/de.rs
+++ b/src/de.rs
@@ -162,11 +162,11 @@ where
     }
 
     fn next(&mut self) -> Result<Option<u8>> {
-        self.read.next().map_err(Error::io)
+        self.read.next()
     }
 
     fn peek(&mut self) -> Result<Option<u8>> {
-        self.read.peek().map_err(Error::io)
+        self.read.peek()
     }
 
     fn consume(&mut self) {

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,13 +1,13 @@
 //! Deserialization.
 
 use byteorder::{BigEndian, ByteOrder};
+use core::f32;
+use core::marker::PhantomData;
+use core::result;
+use core::str;
 use half::f16;
 use serde::de;
-use std::f32;
 use std::io;
-use std::marker::PhantomData;
-use std::result;
-use std::str;
 
 use crate::error::{Error, ErrorCode, Result};
 use crate::read::EitherLifetime;

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use std::result;
 
 /// This type represents all possible errors that can occur when serializing or deserializing CBOR
 /// data.
-pub struct Error(Box<ErrorImpl>);
+pub struct Error(ErrorImpl);
 
 /// Alias for a `Result` with the error type `serde_cbor::Error`.
 pub type Result<T> = result::Result<T, Error>;
@@ -33,14 +33,14 @@ impl Error {
     }
 
     pub(crate) fn syntax(code: ErrorCode, offset: u64) -> Error {
-        Error(Box::new(ErrorImpl { code, offset }))
+        Error(ErrorImpl { code, offset })
     }
 
     pub(crate) fn io(error: io::Error) -> Error {
-        Error(Box::new(ErrorImpl {
+        Error(ErrorImpl {
             code: ErrorCode::Io(error),
             offset: 0,
-        }))
+        })
     }
 
     /// Categorizes the cause of this error.
@@ -123,8 +123,8 @@ impl fmt::Display for Error {
 }
 
 impl fmt::Debug for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&*self.0, fmt)
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
     }
 }
 
@@ -133,10 +133,10 @@ impl de::Error for Error {
     where
         T: fmt::Display,
     {
-        Error(Box::new(ErrorImpl {
+        Error(ErrorImpl {
             code: ErrorCode::Message(msg.to_string()),
             offset: 0,
-        }))
+        })
     }
 
     fn invalid_type(unexp: de::Unexpected<'_>, exp: &dyn de::Expected) -> Error {
@@ -153,10 +153,10 @@ impl ser::Error for Error {
     where
         T: fmt::Display,
     {
-        Error(Box::new(ErrorImpl {
+        Error(ErrorImpl {
             code: ErrorCode::Message(msg.to_string()),
             offset: 0,
-        }))
+        })
     }
 }
 
@@ -185,7 +185,7 @@ pub(crate) enum ErrorCode {
 }
 
 impl fmt::Display for ErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ErrorCode::Message(ref msg) => f.write_str(msg),
             ErrorCode::Io(ref err) => fmt::Display::fmt(err, f),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,10 @@
 //! When serializing or deserializing CBOR goes wrong.
+use core::fmt;
+use core::result;
 use serde::de;
 use serde::ser;
 use std::error;
-use std::fmt;
 use std::io;
-use std::result;
 
 /// This type represents all possible errors that can occur when serializing or deserializing CBOR
 /// data.

--- a/src/read.rs
+++ b/src/read.rs
@@ -33,7 +33,7 @@ pub trait Read<'de>: private::Sealed {
         self.clear_buffer();
         self.read_to_buffer(n)?;
 
-        Ok(self.view_buffer())
+        Ok(self.take_buffer())
     }
 
     #[doc(hidden)]
@@ -46,7 +46,7 @@ pub trait Read<'de>: private::Sealed {
     #[doc(hidden)]
     /// Read out everything accumulated in the reader's scratch buffer. This may, as a side effect,
     /// clear it.
-    fn view_buffer<'a>(&'a mut self) -> EitherLifetime<'a, 'de>;
+    fn take_buffer<'a>(&'a mut self) -> EitherLifetime<'a, 'de>;
 
     #[doc(hidden)]
     fn read_into(&mut self, buf: &mut [u8]) -> Result<()>;
@@ -168,7 +168,7 @@ where
         self.scratch.clear();
     }
 
-    fn view_buffer<'a>(&'a mut self) -> EitherLifetime<'a, 'de> {
+    fn take_buffer<'a>(&'a mut self) -> EitherLifetime<'a, 'de> {
         EitherLifetime::Short(&self.scratch)
     }
 
@@ -283,7 +283,7 @@ impl<'a> Read<'a> for SliceRead<'a> {
         Ok(EitherLifetime::Long(slice))
     }
 
-    fn view_buffer<'b>(&'b mut self) -> EitherLifetime<'b, 'a> {
+    fn take_buffer<'b>(&'b mut self) -> EitherLifetime<'b, 'a> {
         EitherLifetime::Short(&self.scratch)
     }
 
@@ -386,7 +386,7 @@ impl<'a> Read<'a> for MutSliceRead<'a> {
         Ok(())
     }
 
-    fn view_buffer<'b>(&'b mut self) -> EitherLifetime<'b, 'a> {
+    fn take_buffer<'b>(&'b mut self) -> EitherLifetime<'b, 'a> {
         let (left, right) = mem::replace(&mut self.slice, &mut []).split_at_mut(self.index);
         self.slice = right;
         self.before += self.index;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,6 @@
-use std::cmp;
+use core::cmp;
+use core::mem;
 use std::io::{self, Read as StdRead};
-use std::mem;
 
 use crate::error::{Error, ErrorCode, Result};
 


### PR DESCRIPTION
While work on #79 was set back by the canonicalization changes (which introduced quite some internal allocation), I'd like to propose a few next steps here for inclusion in the next-version branch.

* 39125f4f0335ac5502db8778f61c4ca8acda1df5 is a renaming step after #81 (originally proposed to happen after review was through to make it easier to follow through the code changes in https://github.com/pyfisch/cbor/pull/81#issuecomment-447261360 -- anyway, should be done as the current name is slightly misleading).
* 0818e2f719b5e9f8e386763a805394b668716d5d just removes a level of needless heap-allocation that's contained within the error module
* 690483435d76ab3d5c77359b638f7c09be6d1cec switches from using std to core wherever feasible (became less of an issue in 2018 edition with the `extern crate core;` being gone); doesn't change the built files because anything used from std here is just a re-export from core
* e4619bcda4bfc5113c963774bc9aca7dfe1d4848 moves the custom IO errors the readers use out of the read signature, and consistently uses error::Result instead.