### PR TITLE
[WIP] no_std support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[alias]
-build_no_std = ["build", "--no-default-features", "--target", "thumbv7em-none-eabihf"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+build_no_std = ["build", "--no-default-features", "--target", "thumbv7em-none-eabihf"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[alias]
-build_no_std = ["build", "--target", "thumbv7em-none-eabihf", "--no-default-features"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+build_no_std = ["build", "--target", "thumbv7em-none-eabihf", "--no-default-features"]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tokamak.toml
 .idea
 *.iml
 examples/ferris.cbor
+.cargo/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ matrix:
 sudo: false
 before_script:
   - rustup component add rustfmt
+  - rustup target add thumbv7em-none-eabihf     # Any target that does not have a standard library will do
 script:
   - cargo fmt --all -- --check
   - cargo build
   - cargo test
+  - cargo build --no-default-features --target thumbv7em-none-eabihf # Test we can build a platform that does not have std.
+  - cargo test --no-default-features --lib --tests # Run no_std tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
   - cargo test
   - cargo build --no-default-features --target thumbv7em-none-eabihf # Test we can build a platform that does not have std.
   - cargo test --no-default-features --lib --tests # Run no_std tests
+  - cargo build --features unsealed_read_write # The crate should still build when the unsealed_read_write feature is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,14 @@ travis-ci = { repository = "pyfisch/cbor" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-byteorder = "1.0.0"
+byteorder = { version = "1.0.0", default-features = false }
 half = "1.2.0"
-serde = "1.0.14"
+serde = { version = "1.0.14", default-features = false }
 
 [dev-dependencies]
-serde_bytes = "0.10"
-serde_derive = "1.0.14"
+serde_bytes = { version = "0.10", default-features = false }
+serde_derive = { version = "1.0.14", default-features = false }
+
+[features]
+default = ["std"]
+std = ["serde/std", "serde_bytes/std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ serde_derive = { version = "1.0.14", default-features = false }
 [features]
 default = ["std"]
 std = ["serde/std", "serde_bytes/std" ]
+unsealed_read_write = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -11,7 +11,10 @@ use serde::de;
 use std::io;
 
 use crate::error::{Error, ErrorCode, Result};
+#[cfg(not(feature = "unsealed_read_write"))]
 use crate::read::EitherLifetime;
+#[cfg(feature = "unsealed_read_write")]
+pub use crate::read::EitherLifetime;
 #[cfg(feature = "std")]
 pub use crate::read::{IoRead, SliceRead};
 pub use crate::read::{MutSliceRead, Read, SliceReadFixed};

--- a/src/de.rs
+++ b/src/de.rs
@@ -48,6 +48,9 @@ where
     Ok(value)
 }
 
+// When the "std" feature is enabled there should be little to no need to ever use this function,
+// as `from_slice` covers all use cases (at the expense of being less efficient).
+#[cfg_attr(feature = "std", doc(hidden))]
 /// Decode a value from CBOR data in a mutable slice.
 ///
 /// This can be used in analogy to `from_slice`. Unlike `from_slice`, this will use the slice's
@@ -63,7 +66,17 @@ where
     Ok(value)
 }
 
-#[doc(hidden)]
+// When the "std" feature is enabled there should be little to no need to ever use this function,
+// as `from_slice` covers all use cases and is much more reliable (at the expense of being less
+// efficient).
+#[cfg_attr(feature = "std", doc(hidden))]
+/// Decode a value from CBOR data using a scratch buffer.
+///
+/// Users should generally prefer to use `from_slice` or `from_mut_slice` over this function,
+/// as decoding may fail when the scratch buffer turns out to be too small.
+///
+/// A realistic use case for this method would be decoding in a `no_std` environment from an
+/// immutable slice that is too large to copy.
 pub fn from_slice_with_scratch<'a, 'b, T>(slice: &'a [u8], scratch: &'b mut [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,

--- a/src/de.rs
+++ b/src/de.rs
@@ -7,11 +7,14 @@ use core::result;
 use core::str;
 use half::f16;
 use serde::de;
+#[cfg(feature = "std")]
 use std::io;
 
 use crate::error::{Error, ErrorCode, Result};
 use crate::read::EitherLifetime;
-pub use crate::read::{IoRead, MutSliceRead, Read, SliceRead};
+#[cfg(feature = "std")]
+pub use crate::read::{IoRead, SliceRead};
+pub use crate::read::{MutSliceRead, Read};
 
 /// Decodes a value from CBOR data in a slice.
 ///
@@ -34,6 +37,7 @@ pub use crate::read::{IoRead, MutSliceRead, Read, SliceRead};
 /// let value: &str = de::from_slice(&v[..]).unwrap();
 /// assert_eq!(value, "foobar");
 /// ```
+#[cfg(feature = "std")]
 pub fn from_slice<'a, T>(slice: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
@@ -80,6 +84,7 @@ where
 /// let value: &str = de::from_reader(&v[..]).unwrap();
 /// assert_eq!(value, "foobar");
 /// ```
+#[cfg(feature = "std")]
 pub fn from_reader<T, R>(reader: R) -> Result<T>
 where
     T: de::DeserializeOwned,
@@ -97,6 +102,7 @@ pub struct Deserializer<R> {
     remaining_depth: u8,
 }
 
+#[cfg(feature = "std")]
 impl<R> Deserializer<IoRead<R>>
 where
     R: io::Read,
@@ -107,6 +113,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> Deserializer<SliceRead<'a>> {
     /// Constructs a `Deserializer` which reads from a slice.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,6 +211,16 @@ impl From<io::Error> for Error {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl From<core::fmt::Error> for Error {
+    fn from(_: core::fmt::Error) -> Error {
+        Error(ErrorImpl {
+            code: ErrorCode::Custom,
+            offset: 0,
+        })
+    }
+}
+
 #[derive(Debug)]
 struct ErrorImpl {
     code: ErrorCode,

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,10 +46,10 @@ impl Error {
         })
     }
 
-    pub(crate) fn scratch_too_small() -> Error {
+    pub(crate) fn scratch_too_small(offset: u64) -> Error {
         Error(ErrorImpl {
             code: ErrorCode::ScratchTooSmall,
-            offset: 0,
+            offset: offset,
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,13 @@ impl Error {
         })
     }
 
+    pub(crate) fn scratch_too_small() -> Error {
+        Error(ErrorImpl {
+            code: ErrorCode::ScratchTooSmall,
+            offset: 0,
+        })
+    }
+
     /// Categorizes the cause of this error.
     pub fn classify(&self) -> Category {
         match self.0.code {
@@ -55,6 +62,7 @@ impl Error {
             ErrorCode::Io(_) => Category::Io,
             #[cfg(not(feature = "std"))]
             ErrorCode::Custom => Category::Io,
+            ErrorCode::ScratchTooSmall => Category::Io,
             ErrorCode::EofWhileParsingValue
             | ErrorCode::EofWhileParsingArray
             | ErrorCode::EofWhileParsingMap => Category::Eof,
@@ -216,6 +224,7 @@ pub(crate) enum ErrorCode {
     Io(io::Error),
     #[cfg(not(feature = "std"))]
     Custom,
+    ScratchTooSmall,
     EofWhileParsingValue,
     EofWhileParsingArray,
     EofWhileParsingMap,
@@ -239,6 +248,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::Io(ref err) => fmt::Display::fmt(err, f),
             #[cfg(not(feature = "std"))]
             ErrorCode::Custom => f.write_str("Unknown error"),
+            ErrorCode::ScratchTooSmall => f.write_str("Scratch buffer too small"),
             ErrorCode::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
             ErrorCode::EofWhileParsingArray => f.write_str("EOF while parsing an array"),
             ErrorCode::EofWhileParsingMap => f.write_str("EOF while parsing a map"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,6 +161,7 @@ impl de::Error for Error {
     where
         T: fmt::Display,
     {
+        // TODO propagate at least something
         Error(ErrorImpl {
             code: ErrorCode::Custom,
             offset: 0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Category {
     Syntax,
     /// The error was caused by input data that was semantically incorrect.
     Data,
-    /// The error was causeed by prematurely reaching the end of the input data.
+    /// The error was caused by prematurely reaching the end of the input data.
     Eof,
 }
 
@@ -47,6 +47,7 @@ impl Error {
     }
 
     #[cfg(feature = "unsealed_read_write")]
+    /// Creates an error signalling that the scratch buffer was too small to fit the data.
     pub fn scratch_too_small(offset: u64) -> Error {
         Error(ErrorImpl {
             code: ErrorCode::ScratchTooSmall,
@@ -58,11 +59,14 @@ impl Error {
     pub(crate) fn scratch_too_small(offset: u64) -> Error {
         Error(ErrorImpl {
             code: ErrorCode::ScratchTooSmall,
-            offset: offset,
+            offset,
         })
     }
 
     #[cfg(feature = "unsealed_read_write")]
+    /// Creates an error with a custom message.
+    ///
+    /// **Note**: When the "std" feature is disabled, the message will be discarded.
     pub fn message<T: fmt::Display>(_msg: T) -> Error {
         #[cfg(not(feature = "std"))]
         {
@@ -151,6 +155,16 @@ impl Error {
     pub fn is_eof(&self) -> bool {
         match self.classify() {
             Category::Eof => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if this error was caused by the scratch buffer being too small.
+    ///
+    /// Note this being `true` implies that `is_io()` is also `true`.
+    pub fn is_scratch_too_small(&self) -> bool {
+        match self.0.code {
+            ErrorCode::ScratchTooSmall => true,
             _ => false,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,7 +170,7 @@ impl de::Error for Error {
 
 #[cfg(feature = "std")]
 impl ser::Error for Error {
-    fn custom<T>(_msg: T) -> Error
+    fn custom<T>(msg: T) -> Error
     where
         T: fmt::Display,
     {
@@ -195,6 +195,13 @@ impl ser::Error for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error {
+        Error::io(e)
+    }
+}
+
 #[derive(Debug)]
 struct ErrorImpl {
     code: ErrorCode,
@@ -207,6 +214,7 @@ pub(crate) enum ErrorCode {
     Message(String),
     #[cfg(feature = "std")]
     Io(io::Error),
+    #[cfg(not(feature = "std"))]
     Custom,
     EofWhileParsingValue,
     EofWhileParsingArray,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ extern crate serde;
 pub mod de;
 pub mod error;
 mod read;
+mod write;
 
 // TODO re-enable
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,11 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// When we are running tests in no_std mode we need to explicitly link std, because `cargo test`
+// will not work without it.
+#[cfg(all(not(feature = "std"), test))]
+extern crate std;
+
 #[macro_use]
 extern crate serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,23 +154,22 @@ extern crate serde;
 pub mod de;
 pub mod error;
 mod read;
-mod write;
-
-#[cfg(feature = "std")]
 pub mod ser;
+mod write;
 
 #[cfg(feature = "std")]
 pub mod value;
 
 #[doc(inline)]
-pub use crate::de::{from_mut_slice, Deserializer, StreamDeserializer};
+pub use crate::de::{from_mut_slice, from_slice_with_scratch, Deserializer, StreamDeserializer};
 #[doc(inline)]
 #[cfg(feature = "std")]
 pub use crate::de::{from_reader, from_slice};
 
 #[doc(inline)]
 #[cfg(feature = "std")]
-pub use crate::ser::{to_vec, to_vec_with_options, to_writer, Serializer, SerializerOptions};
+pub use crate::ser::{to_vec, to_vec_with_options, to_writer};
+pub use crate::ser::{Serializer, SerializerOptions};
 #[doc(inline)]
 #[cfg(feature = "std")]
 pub use crate::value::{from_value, to_value, ObjectKey, Value};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 //! ```
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
 extern crate serde;
@@ -153,12 +154,23 @@ extern crate serde;
 pub mod de;
 pub mod error;
 mod read;
+
+// TODO re-enable
+#[cfg(feature = "std")]
 pub mod ser;
+
+#[cfg(feature = "std")]
 pub mod value;
 
 #[doc(inline)]
-pub use crate::de::{from_mut_slice, from_reader, from_slice, Deserializer, StreamDeserializer};
+pub use crate::de::{from_mut_slice, Deserializer, StreamDeserializer};
 #[doc(inline)]
+#[cfg(feature = "std")]
+pub use crate::de::{from_reader, from_slice};
+
+#[doc(inline)]
+#[cfg(feature = "std")]
 pub use crate::ser::{to_vec, to_vec_with_options, to_writer, Serializer, SerializerOptions};
 #[doc(inline)]
+#[cfg(feature = "std")]
 pub use crate::value::{from_value, to_value, ObjectKey, Value};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@ pub mod error;
 mod read;
 mod write;
 
-// TODO re-enable
 #[cfg(feature = "std")]
 pub mod ser;
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -113,8 +113,11 @@ pub trait Read<'de> {
     fn offset(&self) -> u64;
 }
 
+/// Represents a buffer with one of two lifetimes.
 pub enum EitherLifetime<'short, 'long> {
+    /// The short lifetime
     Short(&'short [u8]),
+    /// The long lifetime
     Long(&'long [u8]),
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -23,7 +23,7 @@ pub trait Read<'de>: private::Sealed {
     ///
     /// This may, as a side effect, clear the reader's scratch buffer (as the provided
     /// implementation does).
-    ///
+
     // A more appropriate lifetime setup for this (that would allow the Deserializer::convert_str
     // to stay a function) would be something like `fn read<'a, 'r: 'a>(&'a mut 'r immut self, ...) -> ...
     // EitherLifetime<'r, 'de>>`, which borrows self mutably for the duration of the function and
@@ -73,7 +73,7 @@ pub trait Read<'de> {
     ///
     /// This may, as a side effect, clear the reader's scratch buffer (as the provided
     /// implementation does).
-    ///
+
     // A more appropriate lifetime setup for this (that would allow the Deserializer::convert_str
     // to stay a function) would be something like `fn read<'a, 'r: 'a>(&'a mut 'r immut self, ...) -> ...
     // EitherLifetime<'r, 'de>>`, which borrows self mutably for the duration of the function and

--- a/src/read.rs
+++ b/src/read.rs
@@ -406,7 +406,7 @@ impl<'a, 'b> SliceReadFixed<'a, 'b> {
     fn scratch_end(&self, n: usize) -> Result<usize> {
         match self.scratch_index.checked_add(n) {
             Some(end) if end <= self.scratch.len() => Ok(end),
-            _ => Err(Error::scratch_too_small()),
+            _ => Err(Error::scratch_too_small(self.index as u64)),
         }
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "std")]
 use core::cmp;
 use core::mem;
+
+#[cfg(feature = "std")]
 use std::io::{self, Read as StdRead};
 
 use crate::error::{Error, ErrorCode, Result};
@@ -68,6 +71,7 @@ mod private {
 }
 
 /// CBOR input source that reads from a std::io input stream.
+#[cfg(feature = "std")]
 pub struct IoRead<R>
 where
     R: io::Read,
@@ -77,6 +81,7 @@ where
     ch: Option<u8>,
 }
 
+#[cfg(feature = "std")]
 impl<R> IoRead<R>
 where
     R: io::Read,
@@ -104,8 +109,10 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<R> private::Sealed for IoRead<R> where R: io::Read {}
 
+#[cfg(feature = "std")]
 impl<'de, R> Read<'de> for IoRead<R>
 where
     R: io::Read,
@@ -192,11 +199,13 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 struct OffsetReader<R> {
     reader: R,
     offset: u64,
 }
 
+#[cfg(feature = "std")]
 impl<R> io::Read for OffsetReader<R>
 where
     R: io::Read,
@@ -212,12 +221,14 @@ where
 }
 
 /// A CBOR input source that reads from a slice of bytes.
+#[cfg(feature = "std")]
 pub struct SliceRead<'a> {
     slice: &'a [u8],
     scratch: Vec<u8>,
     index: usize,
 }
 
+#[cfg(feature = "std")]
 impl<'a> SliceRead<'a> {
     /// Creates a CBOR input source to read from a slice of bytes.
     pub fn new(slice: &'a [u8]) -> SliceRead<'a> {
@@ -239,8 +250,10 @@ impl<'a> SliceRead<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> private::Sealed for SliceRead<'a> {}
 
+#[cfg(feature = "std")]
 impl<'a> Read<'a> for SliceRead<'a> {
     #[inline]
     fn next(&mut self) -> Result<Option<u8>> {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "std")]
 pub use crate::write::IoWrite;
-pub use crate::write::Write;
+pub use crate::write::{SliceWrite, Write};
 
 use crate::error::{Error, Result};
 use byteorder::{BigEndian, ByteOrder};
@@ -98,6 +98,7 @@ where
     to_writer_packed(&mut vec, value)?;
     Ok(vec)
 }
+
 /// Serializes a value without names to a vector and adds a CBOR self-describe tag.
 ///
 /// Struct fields and enum variants are identified by their numeric indices rather than names to

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,16 +1,15 @@
 //! Serialize a Rust data structure to CBOR data.
-use crate::write::Write;
+
+#[cfg(feature = "std")]
+pub use crate::write::StdWriter;
+pub use crate::write::Write;
+
+use crate::error::{Error, Result};
 use byteorder::{BigEndian, ByteOrder};
 use half::f16;
 use serde::ser::{self, Serialize};
-
 #[cfg(feature = "std")]
 use std::io;
-
-#[cfg(feature = "std")]
-use crate::write::StdWriter;
-
-use crate::error::{Error, Result};
 
 /// Serializes a value to a writer.
 #[cfg(feature = "std")]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,7 +1,7 @@
 //! Serialize a Rust data structure to CBOR data.
 
 #[cfg(feature = "std")]
-pub use crate::write::StdWriter;
+pub use crate::write::IoWrite;
 pub use crate::write::Write;
 
 use crate::error::{Error, Result};
@@ -18,7 +18,7 @@ where
     W: io::Write,
     T: ser::Serialize,
 {
-    value.serialize(&mut Serializer::new(&mut StdWriter::new(writer)))
+    value.serialize(&mut Serializer::new(&mut IoWrite::new(writer)))
 }
 
 /// Serializes a value to a writer and adds a CBOR self-describe tag.
@@ -28,7 +28,7 @@ where
     W: io::Write,
     T: ser::Serialize,
 {
-    let mut writer = StdWriter::new(writer);
+    let mut writer = IoWrite::new(writer);
     let mut ser = Serializer::new(&mut writer);
     ser.self_describe()?;
     value.serialize(&mut ser)
@@ -44,7 +44,7 @@ where
     W: io::Write,
     T: ser::Serialize,
 {
-    value.serialize(&mut Serializer::packed(&mut StdWriter::new(writer)))
+    value.serialize(&mut Serializer::packed(&mut IoWrite::new(writer)))
 }
 
 /// Serializes a value without names to a writer and adds a CBOR self-describe tag.
@@ -57,7 +57,7 @@ where
     W: io::Write,
     T: ser::Serialize,
 {
-    let mut writer = StdWriter::new(writer);
+    let mut writer = IoWrite::new(writer);
     let mut ser = Serializer::packed(&mut writer);
     ser.self_describe()?;
     value.serialize(&mut ser)
@@ -197,10 +197,12 @@ where
     W: Write,
 {
     /// Creates a new CBOR serializer.
+    ///
+    /// `to_vec` and `to_writer` should normally be used instead of this method.
     #[inline]
     pub fn new(writer: W) -> Serializer<W> {
         Serializer {
-            writer,
+            writer: writer.into(),
             packed: false,
             enum_as_map: false,
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,7 +10,7 @@ use crate::error;
 /// but has a smaller and more general API.
 ///
 /// Any object implementing `std::io::Write`
-/// can be wrapped in an [`StdWriter`](../write/struct.StdWriter.html) that implements
+/// can be wrapped in an [`IoWrite`](../write/struct.IoWrite.html) that implements
 /// this trait for the underlying object.
 pub trait Write: private::Sealed {
     /// The type of error returned when a write operation fails.
@@ -29,7 +29,7 @@ pub trait Write: private::Sealed {
 /// but has a smaller and more general API.
 ///
 /// Any object implementing `std::io::Write`
-/// can be wrapped in an [`StdWriter`](../write/struct.StdWriter.html) that implements
+/// can be wrapped in an [`IoWrite`](../write/struct.IoWrite.html) that implements
 /// this trait for the underlying object.
 ///
 /// This trait is sealed by default, enabling the `unsealed_read_write` feature removes this bound
@@ -65,18 +65,18 @@ impl<W> private::Sealed for &mut W where W: Write {}
 /// A wrapper for types that implement
 /// [`std::io::Write`](https://doc.rust-lang.org/std/io/trait.Write.html) to implement the local
 /// [`Write`](trait.Write.html) trait.
-pub struct StdWriter<'a, W>(&'a mut W);
+pub struct IoWrite<'a, W>(&'a mut W);
 
 #[cfg(feature = "std")]
-impl<'a, W: io::Write> StdWriter<'a, W> {
+impl<'a, W: io::Write> IoWrite<'a, W> {
     /// Wraps an `io::Write` writer to make it compatible with [`Write`](trait.Write.html)
-    pub fn new(w: &'a mut W) -> StdWriter<'a, W> {
-        StdWriter(w)
+    pub fn new(w: &'a mut W) -> IoWrite<'a, W> {
+        IoWrite(w)
     }
 }
 
 #[cfg(feature = "std")]
-impl<'a, W: io::Write> Write for StdWriter<'a, W> {
+impl<'a, W: io::Write> Write for IoWrite<'a, W> {
     type Error = io::Error;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
@@ -85,7 +85,7 @@ impl<'a, W: io::Write> Write for StdWriter<'a, W> {
 }
 
 #[cfg(all(feature = "std", not(feature = "unsealed_read_write")))]
-impl<'a, W> private::Sealed for StdWriter<'a, W> where W: io::Write {}
+impl<'a, W> private::Sealed for IoWrite<'a, W> where W: io::Write {}
 
 // TODO this should be possible with just alloc
 #[cfg(feature = "std")]
@@ -97,5 +97,5 @@ impl Write for Vec<u8> {
     }
 }
 
-#[cfg(not(feature = "unsealed_read_write"))]
+#[cfg(all(feature = "std", not(feature = "unsealed_read_write")))]
 impl private::Sealed for Vec<u8> {}

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,10 +3,48 @@ use std::io;
 
 use crate::error;
 
-pub trait Write {
+#[cfg(not(feature = "unsealed_read_write"))]
+/// A sink for serialized CBOR.
+///
+/// This trait is similar to the [`Write`]() trait in the standard library,
+/// but has a smaller and more general API.
+///
+/// Any object implementing `std::io::Write`
+/// can be wrapped in an [`StdWriter`](../write/struct.StdWriter.html) that implements
+/// this trait for the underlying object.
+pub trait Write: private::Sealed {
+    /// The type of error returned when a write operation fails.
+    #[doc(hidden)]
     type Error: Into<error::Error>;
 
+    /// Attempts to write an entire buffer into this write.
+    #[doc(hidden)]
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+}
+
+#[cfg(feature = "unsealed_read_write")]
+/// A sink for serialized CBOR.
+///
+/// This trait is similar to the [`Write`]() trait in the standard library,
+/// but has a smaller and more general API.
+///
+/// Any object implementing `std::io::Write`
+/// can be wrapped in an [`StdWriter`](../write/struct.StdWriter.html) that implements
+/// this trait for the underlying object.
+///
+/// This trait is sealed by default, enabling the `unsealed_read_write` feature removes this bound
+/// to allow objects outside of this crate to implement this trait.
+pub trait Write {
+    /// The type of error returned when a write operation fails.
+    type Error: Into<error::Error>;
+
+    /// Attempts to write an entire buffer into this write.
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+}
+
+#[cfg(not(feature = "unsealed_read_write"))]
+mod private {
+    pub trait Sealed {}
 }
 
 impl<W> Write for &mut W
@@ -20,11 +58,18 @@ where
     }
 }
 
+#[cfg(not(feature = "unsealed_read_write"))]
+impl<W> private::Sealed for &mut W where W: Write {}
+
 #[cfg(feature = "std")]
+/// A wrapper for types that implement
+/// [`std::io::Write`](https://doc.rust-lang.org/std/io/trait.Write.html) to implement the local
+/// [`Write`](trait.Write.html) trait.
 pub struct StdWriter<'a, W>(&'a mut W);
 
 #[cfg(feature = "std")]
 impl<'a, W: io::Write> StdWriter<'a, W> {
+    /// Wraps an `io::Write` writer to make it compatible with [`Write`](trait.Write.html)
     pub fn new(w: &'a mut W) -> StdWriter<'a, W> {
         StdWriter(w)
     }
@@ -39,6 +84,9 @@ impl<'a, W: io::Write> Write for StdWriter<'a, W> {
     }
 }
 
+#[cfg(all(feature = "std", not(feature = "unsealed_read_write")))]
+impl<'a, W> private::Sealed for StdWriter<'a, W> where W: io::Write {}
+
 // TODO this should be possible with just alloc
 #[cfg(feature = "std")]
 impl Write for Vec<u8> {
@@ -48,3 +96,6 @@ impl Write for Vec<u8> {
         io::Write::write_all(self, buf)
     }
 }
+
+#[cfg(not(feature = "unsealed_read_write"))]
+impl private::Sealed for Vec<u8> {}

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use core::fmt;
 #[cfg(feature = "std")]
 use std::io;
 
@@ -99,3 +101,24 @@ impl Write for Vec<u8> {
 
 #[cfg(all(feature = "std", not(feature = "unsealed_read_write")))]
 impl private::Sealed for Vec<u8> {}
+
+#[cfg(not(feature = "std"))]
+pub struct FmtWrite<'a, W: Write>(&'a mut W);
+
+#[cfg(not(feature = "std"))]
+impl<'a, W: Write> FmtWrite<'a, W> {
+    /// Wraps an `fmt::Write` writer to make it compatible with [`Write`](trait.Write.html)
+    pub fn new(w: &'a mut W) -> FmtWrite<'a, W> {
+        FmtWrite(w)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a, W: Write> fmt::Write for FmtWrite<'a, W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.0.write_all(s.as_bytes()).map_err(|_| fmt::Error)
+    }
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "unsealed_read_write")))]
+impl<'a, W> private::Sealed for FmtWrite<'a, W> where W: Write {}

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "std")]
+use std::io;
+
+use crate::error;
+
+pub trait Write {
+    type Error: Into<error::Error>;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+}
+
+impl<W> Write for &mut W
+where
+    W: Write,
+{
+    type Error = W::Error;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        (*self).write_all(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct StdWriter<'a, W>(&'a mut W);
+
+#[cfg(feature = "std")]
+impl<'a, W: io::Write> StdWriter<'a, W> {
+    pub fn new(w: &'a mut W) -> StdWriter<'a, W> {
+        StdWriter(w)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, W: io::Write> Write for StdWriter<'a, W> {
+    type Error = io::Error;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        self.0.write_all(buf)
+    }
+}
+
+// TODO this should be possible with just alloc
+#[cfg(feature = "std")]
+impl Write for Vec<u8> {
+    type Error = io::Error;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        io::Write::write_all(self, buf)
+    }
+}

--- a/tests/bennofs.rs
+++ b/tests/bennofs.rs
@@ -21,17 +21,22 @@ enum Color {
     Yellow(u8),
 }
 
-#[test]
-fn test() {
-    let foo = Foo {
-        x: 0xAA,
-        color: Color::Yellow(40),
-    };
-    let example = Example {
-        foo: foo,
-        payload: 0xCC,
-    };
-    let serialized = serde_cbor::ser::to_vec_packed(&example).unwrap();
-    let deserialized: Example = serde_cbor::from_slice(&serialized).unwrap();
-    assert_eq!(example, deserialized);
+#[cfg(feature = "std")]
+mod std_tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let foo = Foo {
+            x: 0xAA,
+            color: Color::Yellow(40),
+        };
+        let example = Example {
+            foo: foo,
+            payload: 0xCC,
+        };
+        let serialized = serde_cbor::ser::to_vec_packed(&example).unwrap();
+        let deserialized: Example = serde_cbor::from_slice(&serialized).unwrap();
+        assert_eq!(example, deserialized);
+    }
 }

--- a/tests/bennofs.rs
+++ b/tests/bennofs.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate serde_derive;
-use serde_cbor;
+
+use serde::Serialize;
+use serde_cbor::ser::SliceWrite;
+use serde_cbor::{self, Serializer};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Example {
@@ -21,22 +24,36 @@ enum Color {
     Yellow(u8),
 }
 
+const EXAMPLE: Example = Example {
+    foo: Foo {
+        x: 0xAA,
+        color: Color::Yellow(40),
+    },
+    payload: 0xCC,
+};
+
 #[cfg(feature = "std")]
 mod std_tests {
     use super::*;
 
     #[test]
     fn test() {
-        let foo = Foo {
-            x: 0xAA,
-            color: Color::Yellow(40),
-        };
-        let example = Example {
-            foo: foo,
-            payload: 0xCC,
-        };
-        let serialized = serde_cbor::ser::to_vec_packed(&example).unwrap();
+        let serialized = serde_cbor::ser::to_vec_packed(&EXAMPLE).unwrap();
         let deserialized: Example = serde_cbor::from_slice(&serialized).unwrap();
-        assert_eq!(example, deserialized);
+        assert_eq!(EXAMPLE, deserialized);
     }
+}
+
+#[test]
+fn test() {
+    let mut slice = [0u8; 64];
+    let writer = SliceWrite::new(&mut slice);
+    let mut serializer = Serializer::packed(writer);
+    EXAMPLE.serialize(&mut serializer).unwrap();
+    let writer = serializer.into_inner();
+    let end = writer.bytes_written();
+    let slice = writer.into_inner();
+    let deserialized: Example =
+        serde_cbor::from_slice_with_scratch(&slice[..end], &mut []).unwrap();
+    assert_eq!(EXAMPLE, deserialized);
 }

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -1,89 +1,92 @@
-use serde_cbor::ObjectKey;
+#[cfg(feature = "std")]
+mod std_tests {
+    use serde_cbor::ObjectKey;
 
-#[test]
-fn integer_canonical_sort_order() {
-    let expected = [
-        0,
-        23,
-        24,
-        255,
-        256,
-        65535,
-        65536,
-        4294967295,
-        -1,
-        -24,
-        -25,
-        -256,
-        -257,
-        -65536,
-        -65537,
-        -4294967296,
-    ]
-    .into_iter()
-    .map(|i| ObjectKey::Integer(*i))
-    .collect::<Vec<_>>();
-
-    let mut sorted = expected.clone();
-    sorted.sort();
-
-    assert_eq!(expected, sorted);
-}
-
-#[test]
-fn string_canonical_sort_order() {
-    let expected = ["", "a", "b", "aa"]
+    #[test]
+    fn integer_canonical_sort_order() {
+        let expected = [
+            0,
+            23,
+            24,
+            255,
+            256,
+            65535,
+            65536,
+            4294967295,
+            -1,
+            -24,
+            -25,
+            -256,
+            -257,
+            -65536,
+            -65537,
+            -4294967296,
+        ]
         .into_iter()
-        .map(|s| ObjectKey::String(s.to_string()))
+        .map(|i| ObjectKey::Integer(*i))
         .collect::<Vec<_>>();
 
-    let mut sorted = expected.clone();
-    sorted.sort();
+        let mut sorted = expected.clone();
+        sorted.sort();
 
-    assert_eq!(expected, sorted);
-}
+        assert_eq!(expected, sorted);
+    }
 
-#[test]
-fn bytes_canonical_sort_order() {
-    let expected = vec![vec![], vec![0u8], vec![1u8], vec![0u8, 0u8]]
+    #[test]
+    fn string_canonical_sort_order() {
+        let expected = ["", "a", "b", "aa"]
+            .into_iter()
+            .map(|s| ObjectKey::String(s.to_string()))
+            .collect::<Vec<_>>();
+
+        let mut sorted = expected.clone();
+        sorted.sort();
+
+        assert_eq!(expected, sorted);
+    }
+
+    #[test]
+    fn bytes_canonical_sort_order() {
+        let expected = vec![vec![], vec![0u8], vec![1u8], vec![0u8, 0u8]]
+            .into_iter()
+            .map(|v| ObjectKey::Bytes(v))
+            .collect::<Vec<_>>();
+
+        let mut sorted = expected.clone();
+        sorted.sort();
+
+        assert_eq!(expected, sorted);
+    }
+
+    #[test]
+    fn simple_data_canonical_sort_order() {
+        let expected = vec![
+            ObjectKey::Bool(false),
+            ObjectKey::Bool(true),
+            ObjectKey::Null,
+        ];
+
+        let mut sorted = expected.clone();
+        sorted.sort();
+
+        assert_eq!(expected, sorted);
+    }
+
+    #[test]
+    fn major_type_canonical_sort_order() {
+        let expected = vec![
+            ObjectKey::Integer(0),
+            ObjectKey::Integer(-1),
+            ObjectKey::Bytes(vec![]),
+            ObjectKey::String("".to_string()),
+            ObjectKey::Null,
+        ]
         .into_iter()
-        .map(|v| ObjectKey::Bytes(v))
         .collect::<Vec<_>>();
 
-    let mut sorted = expected.clone();
-    sorted.sort();
+        let mut sorted = expected.clone();
+        sorted.sort();
 
-    assert_eq!(expected, sorted);
-}
-
-#[test]
-fn simple_data_canonical_sort_order() {
-    let expected = vec![
-        ObjectKey::Bool(false),
-        ObjectKey::Bool(true),
-        ObjectKey::Null,
-    ];
-
-    let mut sorted = expected.clone();
-    sorted.sort();
-
-    assert_eq!(expected, sorted);
-}
-
-#[test]
-fn major_type_canonical_sort_order() {
-    let expected = vec![
-        ObjectKey::Integer(0),
-        ObjectKey::Integer(-1),
-        ObjectKey::Bytes(vec![]),
-        ObjectKey::String("".to_string()),
-        ObjectKey::Null,
-    ]
-    .into_iter()
-    .collect::<Vec<_>>();
-
-    let mut sorted = expected.clone();
-    sorted.sort();
-
-    assert_eq!(expected, sorted);
+        assert_eq!(expected, sorted);
+    }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -159,6 +159,8 @@ fn test_multiple_indefinite_strings() {
     let input = b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff";
     _test_multiple_indefinite_strings(de::from_slice(input));
     _test_multiple_indefinite_strings(de::from_mut_slice(input.to_vec().as_mut()));
+    let mut buf = [0u8; 64];
+    _test_multiple_indefinite_strings(de::from_slice_with_scratch(input, &mut buf));
 }
 fn _test_multiple_indefinite_strings(value: error::Result<Value>) {
     // This assures that buffer rewinding in infinite buffers works as intended.
@@ -317,6 +319,11 @@ fn stream_deserializer_eof_in_indefinite() {
 
         let mut mutcopy = slice[..*end_of_slice].to_vec();
         let mut it = Deserializer::from_mut_slice(mutcopy.as_mut()).into_iter::<Value>();
+        assert!(it.next().unwrap().unwrap_err().is_eof());
+
+        let mut buf = [0u8; 64];
+        let mut it = Deserializer::from_slice_with_scratch(&slice[..*end_of_slice], &mut buf)
+            .into_iter::<Value>();
         assert!(it.next().unwrap().unwrap_err().is_eof());
     }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,351 +1,356 @@
 use serde_cbor;
 
-use serde_bytes::ByteBuf;
-use std::collections::BTreeMap;
+#[cfg(feature = "std")]
+mod std_tests {
+    use serde_bytes::ByteBuf;
+    use std::collections::BTreeMap;
 
-use serde_cbor::{de, error, from_reader, to_vec, Deserializer, ObjectKey, Value};
+    use serde_cbor::{de, error, from_reader, to_vec, Deserializer, ObjectKey, Value};
 
-#[test]
-fn test_string1() {
-    let value: error::Result<Value> = de::from_slice(&[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
-    assert_eq!(value.unwrap(), Value::String("foobar".to_owned()));
-}
+    #[test]
+    fn test_string1() {
+        let value: error::Result<Value> =
+            de::from_slice(&[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+        assert_eq!(value.unwrap(), Value::String("foobar".to_owned()));
+    }
 
-#[test]
-fn test_string2() {
-    let value: error::Result<Value> = de::from_slice(&[
-        0x71, 0x49, 0x20, 0x6d, 0x65, 0x74, 0x20, 0x61, 0x20, 0x74, 0x72, 0x61, 0x76, 0x65, 0x6c,
-        0x6c, 0x65, 0x72,
-    ]);
-    assert_eq!(
-        value.unwrap(),
-        Value::String("I met a traveller".to_owned())
-    );
-}
-
-#[test]
-fn test_string3() {
-    let slice = b"\x78\x2fI met a traveller from an antique land who said";
-    let value: error::Result<Value> = de::from_slice(slice);
-    assert_eq!(
-        value.unwrap(),
-        Value::String("I met a traveller from an antique land who said".to_owned())
-    );
-}
-
-#[test]
-fn test_byte_string() {
-    let value: error::Result<Value> = de::from_slice(&[0x46, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
-    assert_eq!(value.unwrap(), Value::Bytes(b"foobar".to_vec()));
-}
-
-#[test]
-fn test_numbers1() {
-    let value: error::Result<Value> = de::from_slice(&[0x00]);
-    assert_eq!(value.unwrap(), Value::U64(0));
-}
-
-#[test]
-fn test_numbers2() {
-    let value: error::Result<Value> = de::from_slice(&[0x1a, 0x00, 0xbc, 0x61, 0x4e]);
-    assert_eq!(value.unwrap(), Value::U64(12345678));
-}
-
-#[test]
-fn test_numbers3() {
-    let value: error::Result<Value> = de::from_slice(&[0x39, 0x07, 0xde]);
-    assert_eq!(value.unwrap(), Value::I64(-2015));
-}
-
-#[test]
-fn test_bool() {
-    let value: error::Result<Value> = de::from_slice(b"\xf4");
-    assert_eq!(value.unwrap(), Value::Bool(false));
-}
-
-#[test]
-fn test_trailing_bytes() {
-    let value: error::Result<Value> = de::from_slice(b"\xf4trailing");
-    assert!(value.is_err());
-}
-
-#[test]
-fn test_list1() {
-    let value: error::Result<Value> = de::from_slice(b"\x83\x01\x02\x03");
-    assert_eq!(
-        value.unwrap(),
-        Value::Array(vec![Value::U64(1), Value::U64(2), Value::U64(3)])
-    );
-}
-
-#[test]
-fn test_list2() {
-    let value: error::Result<Value> = de::from_slice(b"\x82\x01\x82\x02\x81\x03");
-    assert_eq!(
-        value.unwrap(),
-        Value::Array(vec![
-            Value::U64(1),
-            Value::Array(vec![Value::U64(2), Value::Array(vec![Value::U64(3)])])
-        ])
-    );
-}
-
-#[test]
-fn test_object() {
-    let value: error::Result<Value> = de::from_slice(b"\xa5aaaAabaBacaCadaDaeaE");
-    let mut object = BTreeMap::new();
-    object.insert(
-        ObjectKey::String("a".to_owned()),
-        Value::String("A".to_owned()),
-    );
-    object.insert(
-        ObjectKey::String("b".to_owned()),
-        Value::String("B".to_owned()),
-    );
-    object.insert(
-        ObjectKey::String("c".to_owned()),
-        Value::String("C".to_owned()),
-    );
-    object.insert(
-        ObjectKey::String("d".to_owned()),
-        Value::String("D".to_owned()),
-    );
-    object.insert(
-        ObjectKey::String("e".to_owned()),
-        Value::String("E".to_owned()),
-    );
-    assert_eq!(value.unwrap(), Value::Object(object));
-}
-
-#[test]
-fn test_indefinite_object() {
-    let value: error::Result<Value> = de::from_slice(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff");
-    let mut object = BTreeMap::new();
-    object.insert(ObjectKey::String("a".to_owned()), Value::U64(1));
-    object.insert(
-        ObjectKey::String("b".to_owned()),
-        Value::Array(vec![Value::U64(2), Value::U64(3)]),
-    );
-    assert_eq!(value.unwrap(), Value::Object(object));
-}
-
-#[test]
-fn test_indefinite_list() {
-    let value: error::Result<Value> = de::from_slice(b"\x9f\x01\x02\x03\xff");
-    assert_eq!(
-        value.unwrap(),
-        Value::Array(vec![Value::U64(1), Value::U64(2), Value::U64(3)])
-    );
-}
-
-#[test]
-fn test_indefinite_string() {
-    let value: error::Result<Value> =
-        de::from_slice(b"\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff");
-    assert_eq!(
-        value.unwrap(),
-        Value::String("Mary Had a Little Lamb".to_owned())
-    );
-}
-
-#[test]
-fn test_indefinite_byte_string() {
-    let value: error::Result<Value> = de::from_slice(b"\x5f\x42\x01\x23\x42\x45\x67\xff");
-    assert_eq!(value.unwrap(), Value::Bytes(b"\x01#Eg".to_vec()));
-}
-
-#[test]
-fn test_multiple_indefinite_strings() {
-    let input = b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff";
-    _test_multiple_indefinite_strings(de::from_slice(input));
-    _test_multiple_indefinite_strings(de::from_mut_slice(input.to_vec().as_mut()));
-    let mut buf = [0u8; 64];
-    _test_multiple_indefinite_strings(de::from_slice_with_scratch(input, &mut buf));
-}
-fn _test_multiple_indefinite_strings(value: error::Result<Value>) {
-    // This assures that buffer rewinding in infinite buffers works as intended.
-    assert_eq!(
-        value.unwrap(),
-        Value::Array(vec![
-            Value::String("Mary Had a Little Lamb".to_owned()),
-            Value::Bytes(b"\x01#Eg".to_vec())
-        ])
-    );
-}
-
-#[test]
-fn test_float() {
-    let value: error::Result<Value> = de::from_slice(b"\xfa\x47\xc3\x50\x00");
-    assert_eq!(value.unwrap(), Value::F64(100000.0));
-}
-
-#[test]
-fn test_self_describing() {
-    let value: error::Result<Value> =
-        de::from_slice(&[0xd9, 0xd9, 0xf7, 0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
-    assert_eq!(value.unwrap(), Value::String("foobar".to_owned()));
-}
-
-#[test]
-fn test_f16() {
-    let mut x: Value = de::from_slice(&[0xf9, 0x41, 0x00]).unwrap();
-    assert_eq!(x, Value::F64(2.5));
-    x = de::from_slice(&[0xf9, 0x41, 0x90]).unwrap();
-    assert_eq!(x, Value::F64(2.78125));
-    x = de::from_slice(&[0xf9, 0x50, 0x90]).unwrap();
-    assert_eq!(x, Value::F64(36.5));
-    x = de::from_slice(&[0xf9, 0xd0, 0x90]).unwrap();
-    assert_eq!(x, Value::F64(-36.5));
-}
-
-#[test]
-fn test_crazy_list() {
-    let slice = b"\x88\x1b\x00\x00\x00\x1c\xbe\x99\x1d\xc7\x3b\x00\x7a\xcf\x51\xdc\x51\x70\xdb\x3a\x1b\x3a\x06\xdd\xf5\xf6\xf7\xfb\x41\x76\x5e\xb1\xf8\x00\x00\x00\xf9\x7c\x00";
-    let value: Vec<Value> = de::from_slice(slice).unwrap();
-    assert_eq!(
-        value,
-        vec![
-            Value::U64(123456789959),
-            Value::I64(-34567897654325468),
-            Value::I64(-456787678),
-            Value::Bool(true),
-            Value::Null,
-            Value::Null,
-            Value::F64(23456543.5),
-            Value::F64(::std::f64::INFINITY)
-        ]
-    );
-}
-
-#[test]
-fn test_nan() {
-    let value: f64 = de::from_slice(b"\xf9\x7e\x00").unwrap();
-    assert!(value.is_nan());
-}
-
-#[test]
-fn test_32f16() {
-    let value: f32 = de::from_slice(b"\xf9\x50\x00").unwrap();
-    assert_eq!(value, 32.0f32);
-}
-
-#[test]
-// The file was reported as not working by user kie0tauB
-// but it parses to a cbor value.
-fn test_kietaub_file() {
-    let file = include_bytes!("kietaub.cbor");
-    let value_result: error::Result<Value> = de::from_slice(file);
-    value_result.unwrap();
-}
-
-#[test]
-fn test_option_roundtrip() {
-    let obj1 = Some(10u32);
-
-    let v = to_vec(&obj1).unwrap();
-    let obj2: Result<Option<u32>, _> = serde_cbor::de::from_reader(&v[..]);
-    println!("{:?}", obj2);
-
-    assert_eq!(obj1, obj2.unwrap());
-}
-
-#[test]
-fn test_option_none_roundtrip() {
-    let obj1 = None;
-
-    let v = to_vec(&obj1).unwrap();
-    println!("{:?}", v);
-    let obj2: Result<Option<u32>, _> = serde_cbor::de::from_reader(&v[..]);
-
-    assert_eq!(obj1, obj2.unwrap());
-}
-
-#[test]
-fn test_variable_length_map() {
-    let slice = b"\xbf\x67\x6d\x65\x73\x73\x61\x67\x65\x64\x70\x6f\x6e\x67\xff";
-    let value: Value = de::from_slice(slice).unwrap();
-    let mut map = BTreeMap::new();
-    map.insert(
-        ObjectKey::String("message".to_string()),
-        Value::String("pong".to_string()),
-    );
-    assert_eq!(value, Value::Object(map))
-}
-
-#[test]
-fn test_object_determinism_roundtrip() {
-    let expected = b"\xa2aa\x01ab\x82\x02\x03";
-
-    // 0.1% chance of not catching failure
-    for _ in 0..10 {
+    #[test]
+    fn test_string2() {
+        let value: error::Result<Value> = de::from_slice(&[
+            0x71, 0x49, 0x20, 0x6d, 0x65, 0x74, 0x20, 0x61, 0x20, 0x74, 0x72, 0x61, 0x76, 0x65,
+            0x6c, 0x6c, 0x65, 0x72,
+        ]);
         assert_eq!(
-            &to_vec(&de::from_slice::<Value>(expected).unwrap()).unwrap(),
-            expected
+            value.unwrap(),
+            Value::String("I met a traveller".to_owned())
         );
     }
-}
 
-#[test]
-fn stream_deserializer() {
-    let slice = b"\x01\x66foobar";
-    let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
-    assert_eq!(Value::U64(1), it.next().unwrap().unwrap());
-    assert_eq!(
-        Value::String("foobar".to_string()),
-        it.next().unwrap().unwrap()
-    );
-    assert!(it.next().is_none());
-}
+    #[test]
+    fn test_string3() {
+        let slice = b"\x78\x2fI met a traveller from an antique land who said";
+        let value: error::Result<Value> = de::from_slice(slice);
+        assert_eq!(
+            value.unwrap(),
+            Value::String("I met a traveller from an antique land who said".to_owned())
+        );
+    }
 
-#[test]
-fn stream_deserializer_eof() {
-    let slice = b"\x01\x66foob";
-    let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
-    assert_eq!(Value::U64(1), it.next().unwrap().unwrap());
-    assert!(it.next().unwrap().unwrap_err().is_eof());
-}
+    #[test]
+    fn test_byte_string() {
+        let value: error::Result<Value> =
+            de::from_slice(&[0x46, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+        assert_eq!(value.unwrap(), Value::Bytes(b"foobar".to_vec()));
+    }
 
-#[test]
-fn stream_deserializer_eof_in_indefinite() {
-    let slice = b"\x7f\x65Mary \x64Had \x62a \x60\x67Little \x60\x64Lamb\xff";
-    let indices: &[usize] = &[
-        2,  // announcement but no data
-        10, // mid-buffer EOF
-        12, // neither new element nor end marker
-    ];
-    for end_of_slice in indices {
-        let mut it = Deserializer::from_slice(&slice[..*end_of_slice]).into_iter::<Value>();
-        assert!(it.next().unwrap().unwrap_err().is_eof());
+    #[test]
+    fn test_numbers1() {
+        let value: error::Result<Value> = de::from_slice(&[0x00]);
+        assert_eq!(value.unwrap(), Value::U64(0));
+    }
 
-        let mut mutcopy = slice[..*end_of_slice].to_vec();
-        let mut it = Deserializer::from_mut_slice(mutcopy.as_mut()).into_iter::<Value>();
-        assert!(it.next().unwrap().unwrap_err().is_eof());
+    #[test]
+    fn test_numbers2() {
+        let value: error::Result<Value> = de::from_slice(&[0x1a, 0x00, 0xbc, 0x61, 0x4e]);
+        assert_eq!(value.unwrap(), Value::U64(12345678));
+    }
 
+    #[test]
+    fn test_numbers3() {
+        let value: error::Result<Value> = de::from_slice(&[0x39, 0x07, 0xde]);
+        assert_eq!(value.unwrap(), Value::I64(-2015));
+    }
+
+    #[test]
+    fn test_bool() {
+        let value: error::Result<Value> = de::from_slice(b"\xf4");
+        assert_eq!(value.unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_trailing_bytes() {
+        let value: error::Result<Value> = de::from_slice(b"\xf4trailing");
+        assert!(value.is_err());
+    }
+
+    #[test]
+    fn test_list1() {
+        let value: error::Result<Value> = de::from_slice(b"\x83\x01\x02\x03");
+        assert_eq!(
+            value.unwrap(),
+            Value::Array(vec![Value::U64(1), Value::U64(2), Value::U64(3)])
+        );
+    }
+
+    #[test]
+    fn test_list2() {
+        let value: error::Result<Value> = de::from_slice(b"\x82\x01\x82\x02\x81\x03");
+        assert_eq!(
+            value.unwrap(),
+            Value::Array(vec![
+                Value::U64(1),
+                Value::Array(vec![Value::U64(2), Value::Array(vec![Value::U64(3)])])
+            ])
+        );
+    }
+
+    #[test]
+    fn test_object() {
+        let value: error::Result<Value> = de::from_slice(b"\xa5aaaAabaBacaCadaDaeaE");
+        let mut object = BTreeMap::new();
+        object.insert(
+            ObjectKey::String("a".to_owned()),
+            Value::String("A".to_owned()),
+        );
+        object.insert(
+            ObjectKey::String("b".to_owned()),
+            Value::String("B".to_owned()),
+        );
+        object.insert(
+            ObjectKey::String("c".to_owned()),
+            Value::String("C".to_owned()),
+        );
+        object.insert(
+            ObjectKey::String("d".to_owned()),
+            Value::String("D".to_owned()),
+        );
+        object.insert(
+            ObjectKey::String("e".to_owned()),
+            Value::String("E".to_owned()),
+        );
+        assert_eq!(value.unwrap(), Value::Object(object));
+    }
+
+    #[test]
+    fn test_indefinite_object() {
+        let value: error::Result<Value> = de::from_slice(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff");
+        let mut object = BTreeMap::new();
+        object.insert(ObjectKey::String("a".to_owned()), Value::U64(1));
+        object.insert(
+            ObjectKey::String("b".to_owned()),
+            Value::Array(vec![Value::U64(2), Value::U64(3)]),
+        );
+        assert_eq!(value.unwrap(), Value::Object(object));
+    }
+
+    #[test]
+    fn test_indefinite_list() {
+        let value: error::Result<Value> = de::from_slice(b"\x9f\x01\x02\x03\xff");
+        assert_eq!(
+            value.unwrap(),
+            Value::Array(vec![Value::U64(1), Value::U64(2), Value::U64(3)])
+        );
+    }
+
+    #[test]
+    fn test_indefinite_string() {
+        let value: error::Result<Value> =
+            de::from_slice(b"\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff");
+        assert_eq!(
+            value.unwrap(),
+            Value::String("Mary Had a Little Lamb".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_indefinite_byte_string() {
+        let value: error::Result<Value> = de::from_slice(b"\x5f\x42\x01\x23\x42\x45\x67\xff");
+        assert_eq!(value.unwrap(), Value::Bytes(b"\x01#Eg".to_vec()));
+    }
+
+    #[test]
+    fn test_multiple_indefinite_strings() {
+        let input = b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff";
+        _test_multiple_indefinite_strings(de::from_slice(input));
+        _test_multiple_indefinite_strings(de::from_mut_slice(input.to_vec().as_mut()));
         let mut buf = [0u8; 64];
-        let mut it = Deserializer::from_slice_with_scratch(&slice[..*end_of_slice], &mut buf)
-            .into_iter::<Value>();
+        _test_multiple_indefinite_strings(de::from_slice_with_scratch(input, &mut buf));
+    }
+    fn _test_multiple_indefinite_strings(value: error::Result<Value>) {
+        // This assures that buffer rewinding in infinite buffers works as intended.
+        assert_eq!(
+            value.unwrap(),
+            Value::Array(vec![
+                Value::String("Mary Had a Little Lamb".to_owned()),
+                Value::Bytes(b"\x01#Eg".to_vec())
+            ])
+        );
+    }
+
+    #[test]
+    fn test_float() {
+        let value: error::Result<Value> = de::from_slice(b"\xfa\x47\xc3\x50\x00");
+        assert_eq!(value.unwrap(), Value::F64(100000.0));
+    }
+
+    #[test]
+    fn test_self_describing() {
+        let value: error::Result<Value> =
+            de::from_slice(&[0xd9, 0xd9, 0xf7, 0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+        assert_eq!(value.unwrap(), Value::String("foobar".to_owned()));
+    }
+
+    #[test]
+    fn test_f16() {
+        let mut x: Value = de::from_slice(&[0xf9, 0x41, 0x00]).unwrap();
+        assert_eq!(x, Value::F64(2.5));
+        x = de::from_slice(&[0xf9, 0x41, 0x90]).unwrap();
+        assert_eq!(x, Value::F64(2.78125));
+        x = de::from_slice(&[0xf9, 0x50, 0x90]).unwrap();
+        assert_eq!(x, Value::F64(36.5));
+        x = de::from_slice(&[0xf9, 0xd0, 0x90]).unwrap();
+        assert_eq!(x, Value::F64(-36.5));
+    }
+
+    #[test]
+    fn test_crazy_list() {
+        let slice = b"\x88\x1b\x00\x00\x00\x1c\xbe\x99\x1d\xc7\x3b\x00\x7a\xcf\x51\xdc\x51\x70\xdb\x3a\x1b\x3a\x06\xdd\xf5\xf6\xf7\xfb\x41\x76\x5e\xb1\xf8\x00\x00\x00\xf9\x7c\x00";
+        let value: Vec<Value> = de::from_slice(slice).unwrap();
+        assert_eq!(
+            value,
+            vec![
+                Value::U64(123456789959),
+                Value::I64(-34567897654325468),
+                Value::I64(-456787678),
+                Value::Bool(true),
+                Value::Null,
+                Value::Null,
+                Value::F64(23456543.5),
+                Value::F64(::std::f64::INFINITY)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nan() {
+        let value: f64 = de::from_slice(b"\xf9\x7e\x00").unwrap();
+        assert!(value.is_nan());
+    }
+
+    #[test]
+    fn test_32f16() {
+        let value: f32 = de::from_slice(b"\xf9\x50\x00").unwrap();
+        assert_eq!(value, 32.0f32);
+    }
+
+    #[test]
+    // The file was reported as not working by user kie0tauB
+    // but it parses to a cbor value.
+    fn test_kietaub_file() {
+        let file = include_bytes!("kietaub.cbor");
+        let value_result: error::Result<Value> = de::from_slice(file);
+        value_result.unwrap();
+    }
+
+    #[test]
+    fn test_option_roundtrip() {
+        let obj1 = Some(10u32);
+
+        let v = to_vec(&obj1).unwrap();
+        let obj2: Result<Option<u32>, _> = serde_cbor::de::from_reader(&v[..]);
+        println!("{:?}", obj2);
+
+        assert_eq!(obj1, obj2.unwrap());
+    }
+
+    #[test]
+    fn test_option_none_roundtrip() {
+        let obj1 = None;
+
+        let v = to_vec(&obj1).unwrap();
+        println!("{:?}", v);
+        let obj2: Result<Option<u32>, _> = serde_cbor::de::from_reader(&v[..]);
+
+        assert_eq!(obj1, obj2.unwrap());
+    }
+
+    #[test]
+    fn test_variable_length_map() {
+        let slice = b"\xbf\x67\x6d\x65\x73\x73\x61\x67\x65\x64\x70\x6f\x6e\x67\xff";
+        let value: Value = de::from_slice(slice).unwrap();
+        let mut map = BTreeMap::new();
+        map.insert(
+            ObjectKey::String("message".to_string()),
+            Value::String("pong".to_string()),
+        );
+        assert_eq!(value, Value::Object(map))
+    }
+
+    #[test]
+    fn test_object_determinism_roundtrip() {
+        let expected = b"\xa2aa\x01ab\x82\x02\x03";
+
+        // 0.1% chance of not catching failure
+        for _ in 0..10 {
+            assert_eq!(
+                &to_vec(&de::from_slice::<Value>(expected).unwrap()).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn stream_deserializer() {
+        let slice = b"\x01\x66foobar";
+        let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
+        assert_eq!(Value::U64(1), it.next().unwrap().unwrap());
+        assert_eq!(
+            Value::String("foobar".to_string()),
+            it.next().unwrap().unwrap()
+        );
+        assert!(it.next().is_none());
+    }
+
+    #[test]
+    fn stream_deserializer_eof() {
+        let slice = b"\x01\x66foob";
+        let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
+        assert_eq!(Value::U64(1), it.next().unwrap().unwrap());
         assert!(it.next().unwrap().unwrap_err().is_eof());
     }
-}
 
-#[test]
-fn test_large_bytes() {
-    let expected = (0..2 * 1024 * 1024)
-        .map(|i| (i * 7) as u8)
-        .collect::<Vec<_>>();
-    let expected = ByteBuf::from(expected);
-    let v = to_vec(&expected).unwrap();
+    #[test]
+    fn stream_deserializer_eof_in_indefinite() {
+        let slice = b"\x7f\x65Mary \x64Had \x62a \x60\x67Little \x60\x64Lamb\xff";
+        let indices: &[usize] = &[
+            2,  // announcement but no data
+            10, // mid-buffer EOF
+            12, // neither new element nor end marker
+        ];
+        for end_of_slice in indices {
+            let mut it = Deserializer::from_slice(&slice[..*end_of_slice]).into_iter::<Value>();
+            assert!(it.next().unwrap().unwrap_err().is_eof());
 
-    let actual = from_reader(&v[..]).unwrap();
-    assert_eq!(expected, actual);
-}
+            let mut mutcopy = slice[..*end_of_slice].to_vec();
+            let mut it = Deserializer::from_mut_slice(mutcopy.as_mut()).into_iter::<Value>();
+            assert!(it.next().unwrap().unwrap_err().is_eof());
 
-#[test]
-fn crash() {
-    let file = include_bytes!("crash.cbor");
-    let value_result: error::Result<Value> = de::from_slice(file);
-    assert_eq!(
-        value_result.unwrap_err().classify(),
-        serde_cbor::error::Category::Syntax
-    );
+            let mut buf = [0u8; 64];
+            let mut it = Deserializer::from_slice_with_scratch(&slice[..*end_of_slice], &mut buf)
+                .into_iter::<Value>();
+            assert!(it.next().unwrap().unwrap_err().is_eof());
+        }
+    }
+
+    #[test]
+    fn test_large_bytes() {
+        let expected = (0..2 * 1024 * 1024)
+            .map(|i| (i * 7) as u8)
+            .collect::<Vec<_>>();
+        let expected = ByteBuf::from(expected);
+        let v = to_vec(&expected).unwrap();
+
+        let actual = from_reader(&v[..]).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn crash() {
+        let file = include_bytes!("crash.cbor");
+        let value_result: error::Result<Value> = de::from_slice(file);
+        assert_eq!(
+            value_result.unwrap_err().classify(),
+            serde_cbor::error::Category::Syntax
+        );
+    }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,4 +1,47 @@
+#[macro_use]
+extern crate serde_derive;
+
 use serde_cbor;
+use serde_cbor::de;
+
+#[test]
+fn test_str() {
+    let s: &str =
+        de::from_slice_with_scratch(&[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72], &mut []).unwrap();
+    assert_eq!(s, "foobar");
+}
+
+#[test]
+fn test_bytes() {
+    let s: &[u8] =
+        de::from_slice_with_scratch(&[0x46, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72], &mut []).unwrap();
+    assert_eq!(s, b"foobar");
+}
+
+#[test]
+fn test_int() {
+    let num: i64 = de::from_slice_with_scratch(&[0x39, 0x07, 0xde], &mut []).unwrap();
+    assert_eq!(num, -2015);
+}
+
+#[test]
+fn test_float() {
+    let float: f64 = de::from_slice_with_scratch(b"\xfa\x47\xc3\x50\x00", &mut []).unwrap();
+    assert_eq!(float, 100000.0);
+}
+
+#[test]
+fn test_indefinite_object() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo {
+        a: u64,
+        b: [u64; 2],
+    }
+    let expected = Foo { a: 1, b: [2, 3] };
+    let actual: Foo =
+        de::from_slice_with_scratch(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff", &mut []).unwrap();
+    assert_eq!(expected, actual);
+}
 
 #[cfg(feature = "std")]
 mod std_tests {

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -3,197 +3,200 @@ use serde_cbor;
 #[macro_use]
 extern crate serde_derive;
 
-use std::collections::BTreeMap;
+#[cfg(feature = "std")]
+mod std_tests {
+    use std::collections::BTreeMap;
 
-use serde_cbor::{from_slice, to_vec, ObjectKey, Value};
+    use serde_cbor::{from_slice, to_vec, ObjectKey, Value};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-enum Enum {
-    A,
-    B,
-}
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    enum Enum {
+        A,
+        B,
+    }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-struct EnumStruct {
-    e: Enum,
-}
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct EnumStruct {
+        e: Enum,
+    }
 
-#[test]
-fn test_enum() {
-    let enum_struct = EnumStruct { e: Enum::B };
-    let raw = &to_vec(&enum_struct).unwrap();
-    println!("raw enum {:?}", raw);
-    let re: EnumStruct = from_slice(raw).unwrap();
-    assert_eq!(enum_struct, re);
-}
+    #[test]
+    fn test_enum() {
+        let enum_struct = EnumStruct { e: Enum::B };
+        let raw = &to_vec(&enum_struct).unwrap();
+        println!("raw enum {:?}", raw);
+        let re: EnumStruct = from_slice(raw).unwrap();
+        assert_eq!(enum_struct, re);
+    }
 
-#[repr(u16)]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-enum ReprEnum {
-    A,
-    B,
-}
+    #[repr(u16)]
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    enum ReprEnum {
+        A,
+        B,
+    }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-struct ReprEnumStruct {
-    e: ReprEnum,
-}
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct ReprEnumStruct {
+        e: ReprEnum,
+    }
 
-#[test]
-fn test_repr_enum() {
-    let repr_enum_struct = ReprEnumStruct { e: ReprEnum::B };
-    let re: ReprEnumStruct = from_slice(&to_vec(&repr_enum_struct).unwrap()).unwrap();
-    assert_eq!(repr_enum_struct, re);
-}
+    #[test]
+    fn test_repr_enum() {
+        let repr_enum_struct = ReprEnumStruct { e: ReprEnum::B };
+        let re: ReprEnumStruct = from_slice(&to_vec(&repr_enum_struct).unwrap()).unwrap();
+        assert_eq!(repr_enum_struct, re);
+    }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-enum DataEnum {
-    A(u32),
-    B(bool, u8),
-    C { x: u8, y: String },
-}
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    enum DataEnum {
+        A(u32),
+        B(bool, u8),
+        C { x: u8, y: String },
+    }
 
-#[test]
-fn test_data_enum() {
-    let data_enum_a = DataEnum::A(4);
-    let re_a: DataEnum = from_slice(&to_vec(&data_enum_a).unwrap()).unwrap();
-    assert_eq!(data_enum_a, re_a);
-    let data_enum_b = DataEnum::B(true, 42);
-    let re_b: DataEnum = from_slice(&to_vec(&data_enum_b).unwrap()).unwrap();
-    assert_eq!(data_enum_b, re_b);
-    let data_enum_c = DataEnum::C {
-        x: 3,
-        y: "foo".to_owned(),
-    };
-    println!("{:?}", &to_vec(&data_enum_c).unwrap());
-    let re_c: DataEnum = from_slice(&to_vec(&data_enum_c).unwrap()).unwrap();
-    assert_eq!(data_enum_c, re_c);
-}
+    #[test]
+    fn test_data_enum() {
+        let data_enum_a = DataEnum::A(4);
+        let re_a: DataEnum = from_slice(&to_vec(&data_enum_a).unwrap()).unwrap();
+        assert_eq!(data_enum_a, re_a);
+        let data_enum_b = DataEnum::B(true, 42);
+        let re_b: DataEnum = from_slice(&to_vec(&data_enum_b).unwrap()).unwrap();
+        assert_eq!(data_enum_b, re_b);
+        let data_enum_c = DataEnum::C {
+            x: 3,
+            y: "foo".to_owned(),
+        };
+        println!("{:?}", &to_vec(&data_enum_c).unwrap());
+        let re_c: DataEnum = from_slice(&to_vec(&data_enum_c).unwrap()).unwrap();
+        assert_eq!(data_enum_c, re_c);
+    }
 
-#[test]
-fn test_serialize() {
-    assert_eq!(to_vec(&Enum::A).unwrap(), &[97, 65]);
-    assert_eq!(to_vec(&Enum::B).unwrap(), &[97, 66]);
-    assert_eq!(to_vec(&DataEnum::A(42)).unwrap(), &[130, 97, 65, 24, 42]);
-    assert_eq!(
-        to_vec(&DataEnum::B(true, 9)).unwrap(),
-        &[131, 97, 66, 245, 9]
-    );
-}
+    #[test]
+    fn test_serialize() {
+        assert_eq!(to_vec(&Enum::A).unwrap(), &[97, 65]);
+        assert_eq!(to_vec(&Enum::B).unwrap(), &[97, 66]);
+        assert_eq!(to_vec(&DataEnum::A(42)).unwrap(), &[130, 97, 65, 24, 42]);
+        assert_eq!(
+            to_vec(&DataEnum::B(true, 9)).unwrap(),
+            &[131, 97, 66, 245, 9]
+        );
+    }
 
-#[test]
-fn test_newtype_struct() {
-    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
-    pub struct Newtype(u8);
-    assert_eq!(to_vec(&142u8).unwrap(), to_vec(&Newtype(142u8)).unwrap());
-    assert_eq!(from_slice::<Newtype>(&[24, 142]).unwrap(), Newtype(142));
-}
+    #[test]
+    fn test_newtype_struct() {
+        #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+        pub struct Newtype(u8);
+        assert_eq!(to_vec(&142u8).unwrap(), to_vec(&Newtype(142u8)).unwrap());
+        assert_eq!(from_slice::<Newtype>(&[24, 142]).unwrap(), Newtype(142));
+    }
 
-#[derive(Deserialize, PartialEq, Debug)]
-enum Foo {
-    #[serde(rename = "require")]
-    Require,
-}
+    #[derive(Deserialize, PartialEq, Debug)]
+    enum Foo {
+        #[serde(rename = "require")]
+        Require,
+    }
 
-#[test]
-fn test_variable_length_array() {
-    let slice = b"\x9F\x67\x72\x65\x71\x75\x69\x72\x65\xFF";
-    let value: Vec<Foo> = from_slice(slice).unwrap();
-    assert_eq!(value, [Foo::Require]);
-}
+    #[test]
+    fn test_variable_length_array() {
+        let slice = b"\x9F\x67\x72\x65\x71\x75\x69\x72\x65\xFF";
+        let value: Vec<Foo> = from_slice(slice).unwrap();
+        assert_eq!(value, [Foo::Require]);
+    }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-enum Bar {
-    Empty,
-    Number(i32),
-    Flag(String, bool),
-    Point { x: i32, y: i32 },
-}
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum Bar {
+        Empty,
+        Number(i32),
+        Flag(String, bool),
+        Point { x: i32, y: i32 },
+    }
 
-#[test]
-fn test_enum_as_map() {
-    // unit variants serialize like bare strings
-    let empty_s = to_vec(&Bar::Empty).unwrap();
-    let empty_str_s = to_vec(&"Empty").unwrap();
-    assert_eq!(empty_s, empty_str_s);
+    #[test]
+    fn test_enum_as_map() {
+        // unit variants serialize like bare strings
+        let empty_s = to_vec(&Bar::Empty).unwrap();
+        let empty_str_s = to_vec(&"Empty").unwrap();
+        assert_eq!(empty_s, empty_str_s);
 
-    // tuple-variants serialize like ["<variant>", values..]
-    let number_s = to_vec(&Bar::Number(42)).unwrap();
-    let number_vec = vec![Value::String("Number".to_string()), Value::I64(42)];
-    let number_vec_s = to_vec(&number_vec).unwrap();
-    assert_eq!(number_s, number_vec_s);
+        // tuple-variants serialize like ["<variant>", values..]
+        let number_s = to_vec(&Bar::Number(42)).unwrap();
+        let number_vec = vec![Value::String("Number".to_string()), Value::I64(42)];
+        let number_vec_s = to_vec(&number_vec).unwrap();
+        assert_eq!(number_s, number_vec_s);
 
-    let flag_s = to_vec(&Bar::Flag("foo".to_string(), true)).unwrap();
-    let flag_vec = vec![
-        Value::String("Flag".to_string()),
-        Value::String("foo".to_string()),
-        Value::Bool(true),
-    ];
-    let flag_vec_s = to_vec(&flag_vec).unwrap();
-    assert_eq!(flag_s, flag_vec_s);
+        let flag_s = to_vec(&Bar::Flag("foo".to_string(), true)).unwrap();
+        let flag_vec = vec![
+            Value::String("Flag".to_string()),
+            Value::String("foo".to_string()),
+            Value::Bool(true),
+        ];
+        let flag_vec_s = to_vec(&flag_vec).unwrap();
+        assert_eq!(flag_s, flag_vec_s);
 
-    // struct-variants serialize like ["<variant>", {struct..}]
-    let point_s = to_vec(&Bar::Point { x: 5, y: -5 }).unwrap();
-    let mut struct_map = BTreeMap::new();
-    struct_map.insert(ObjectKey::String("x".to_string()), Value::I64(5));
-    struct_map.insert(ObjectKey::String("y".to_string()), Value::I64(-5));
-    let point_vec = vec![
-        Value::String("Point".to_string()),
-        Value::Object(struct_map.clone()),
-    ];
-    let point_vec_s = to_vec(&point_vec).unwrap();
-    assert_eq!(point_s, point_vec_s);
+        // struct-variants serialize like ["<variant>", {struct..}]
+        let point_s = to_vec(&Bar::Point { x: 5, y: -5 }).unwrap();
+        let mut struct_map = BTreeMap::new();
+        struct_map.insert(ObjectKey::String("x".to_string()), Value::I64(5));
+        struct_map.insert(ObjectKey::String("y".to_string()), Value::I64(-5));
+        let point_vec = vec![
+            Value::String("Point".to_string()),
+            Value::Object(struct_map.clone()),
+        ];
+        let point_vec_s = to_vec(&point_vec).unwrap();
+        assert_eq!(point_s, point_vec_s);
 
-    // enum_as_map matches serde_json's default serialization for enums.
-    let opts = serde_cbor::SerializerOptions {
-        enum_as_map: true,
-        ..Default::default()
-    };
+        // enum_as_map matches serde_json's default serialization for enums.
+        let opts = serde_cbor::SerializerOptions {
+            enum_as_map: true,
+            ..Default::default()
+        };
 
-    // unit variants still serialize like bare strings
-    let empty_s = opts.to_vec(&Bar::Empty).unwrap();
-    assert_eq!(empty_s, empty_str_s);
+        // unit variants still serialize like bare strings
+        let empty_s = opts.to_vec(&Bar::Empty).unwrap();
+        assert_eq!(empty_s, empty_str_s);
 
-    // 1-element tuple variants serialize like {"<variant>": value}
-    let number_s = opts.to_vec(&Bar::Number(42)).unwrap();
-    let mut number_map = BTreeMap::new();
-    number_map.insert("Number", 42);
-    let number_map_s = to_vec(&number_map).unwrap();
-    assert_eq!(number_s, number_map_s);
+        // 1-element tuple variants serialize like {"<variant>": value}
+        let number_s = opts.to_vec(&Bar::Number(42)).unwrap();
+        let mut number_map = BTreeMap::new();
+        number_map.insert("Number", 42);
+        let number_map_s = to_vec(&number_map).unwrap();
+        assert_eq!(number_s, number_map_s);
 
-    // multi-element tuple variants serialize like {"<variant>": [values..]}
-    let flag_s = opts.to_vec(&Bar::Flag("foo".to_string(), true)).unwrap();
-    let mut flag_map = BTreeMap::new();
-    flag_map.insert(
-        "Flag",
-        vec![Value::String("foo".to_string()), Value::Bool(true)],
-    );
-    let flag_map_s = to_vec(&flag_map).unwrap();
-    assert_eq!(flag_s, flag_map_s);
+        // multi-element tuple variants serialize like {"<variant>": [values..]}
+        let flag_s = opts.to_vec(&Bar::Flag("foo".to_string(), true)).unwrap();
+        let mut flag_map = BTreeMap::new();
+        flag_map.insert(
+            "Flag",
+            vec![Value::String("foo".to_string()), Value::Bool(true)],
+        );
+        let flag_map_s = to_vec(&flag_map).unwrap();
+        assert_eq!(flag_s, flag_map_s);
 
-    // struct-variants serialize like {"<variant>", {struct..}}
-    let point_s = opts.to_vec(&Bar::Point { x: 5, y: -5 }).unwrap();
-    let mut point_map = BTreeMap::new();
-    point_map.insert("Point", Value::Object(struct_map));
-    let point_map_s = to_vec(&point_map).unwrap();
-    assert_eq!(point_s, point_map_s);
+        // struct-variants serialize like {"<variant>", {struct..}}
+        let point_s = opts.to_vec(&Bar::Point { x: 5, y: -5 }).unwrap();
+        let mut point_map = BTreeMap::new();
+        point_map.insert("Point", Value::Object(struct_map));
+        let point_map_s = to_vec(&point_map).unwrap();
+        assert_eq!(point_s, point_map_s);
 
-    // deserialization of all encodings should just work
-    let empty_str_ds = from_slice(&empty_str_s).unwrap();
-    assert_eq!(Bar::Empty, empty_str_ds);
+        // deserialization of all encodings should just work
+        let empty_str_ds = from_slice(&empty_str_s).unwrap();
+        assert_eq!(Bar::Empty, empty_str_ds);
 
-    let number_vec_ds = from_slice(&number_vec_s).unwrap();
-    assert_eq!(Bar::Number(42), number_vec_ds);
-    let number_map_ds = from_slice(&number_map_s).unwrap();
-    assert_eq!(Bar::Number(42), number_map_ds);
+        let number_vec_ds = from_slice(&number_vec_s).unwrap();
+        assert_eq!(Bar::Number(42), number_vec_ds);
+        let number_map_ds = from_slice(&number_map_s).unwrap();
+        assert_eq!(Bar::Number(42), number_map_ds);
 
-    let flag_vec_ds = from_slice(&flag_vec_s).unwrap();
-    assert_eq!(Bar::Flag("foo".to_string(), true), flag_vec_ds);
-    let flag_map_ds = from_slice(&flag_map_s).unwrap();
-    assert_eq!(Bar::Flag("foo".to_string(), true), flag_map_ds);
+        let flag_vec_ds = from_slice(&flag_vec_s).unwrap();
+        assert_eq!(Bar::Flag("foo".to_string(), true), flag_vec_ds);
+        let flag_map_ds = from_slice(&flag_map_s).unwrap();
+        assert_eq!(Bar::Flag("foo".to_string(), true), flag_map_ds);
 
-    let point_vec_ds = from_slice(&point_vec_s).unwrap();
-    assert_eq!(Bar::Point { x: 5, y: -5 }, point_vec_ds);
-    let point_map_ds = from_slice(&point_map_s).unwrap();
-    assert_eq!(Bar::Point { x: 5, y: -5 }, point_map_ds);
+        let point_vec_ds = from_slice(&point_vec_s).unwrap();
+        assert_eq!(Bar::Point { x: 5, y: -5 }, point_vec_ds);
+        let point_map_ds = from_slice(&point_map_s).unwrap();
+        assert_eq!(Bar::Point { x: 5, y: -5 }, point_map_ds);
+    }
 }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,11 +1,10 @@
-use std::collections::BTreeMap;
-
 #[cfg(feature = "std")]
 mod std_tests {
     use serde::Serializer;
     use serde_bytes::{ByteBuf, Bytes};
     use serde_cbor::ser;
     use serde_cbor::{from_slice, to_vec};
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_string() {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,211 +1,214 @@
 use std::collections::BTreeMap;
 
-use serde::Serializer;
-use serde_bytes::{ByteBuf, Bytes};
-use serde_cbor::ser;
-use serde_cbor::{from_slice, to_vec};
+#[cfg(feature = "std")]
+mod std_tests {
+    use serde::Serializer;
+    use serde_bytes::{ByteBuf, Bytes};
+    use serde_cbor::ser;
+    use serde_cbor::{from_slice, to_vec};
 
-#[test]
-fn test_string() {
-    let value = "foobar".to_owned();
-    assert_eq!(&to_vec(&value).unwrap()[..], b"ffoobar");
-}
-
-#[test]
-fn test_list() {
-    let value = vec![1, 2, 3];
-    assert_eq!(&to_vec(&value).unwrap()[..], b"\x83\x01\x02\x03");
-}
-
-#[test]
-fn test_object() {
-    let mut object = BTreeMap::new();
-    object.insert("a".to_owned(), "A".to_owned());
-    object.insert("b".to_owned(), "B".to_owned());
-    object.insert("c".to_owned(), "C".to_owned());
-    object.insert("d".to_owned(), "D".to_owned());
-    object.insert("e".to_owned(), "E".to_owned());
-    let vec = to_vec(&object).unwrap();
-    let test_object = from_slice(&vec[..]).unwrap();
-    assert_eq!(object, test_object);
-}
-
-#[test]
-fn test_object_list_keys() {
-    let mut object = BTreeMap::new();
-    object.insert(vec![0i64], ());
-    object.insert(vec![100i64], ());
-    object.insert(vec![-1i64], ());
-    object.insert(vec![-2i64], ());
-    object.insert(vec![0i64, 0i64], ());
-    object.insert(vec![0i64, -1i64], ());
-    let vec = to_vec(&object).unwrap();
-    assert_eq!(
-        vec![
-            166, 129, 0, 246, 129, 24, 100, 246, 129, 32, 246, 129, 33, 246, 130, 0, 0, 246, 130,
-            0, 32, 246
-        ],
-        vec
-    );
-    let test_object = from_slice(&vec[..]).unwrap();
-    assert_eq!(object, test_object);
-}
-
-#[test]
-fn test_object_object_keys() {
-    use std::iter::FromIterator;
-    let mut object = BTreeMap::new();
-    let keys = vec![
-        vec!["a"],
-        vec!["b"],
-        vec!["c"],
-        vec!["d"],
-        vec!["aa"],
-        vec!["a", "aa"],
-    ]
-    .into_iter()
-    .map(|v| BTreeMap::from_iter(v.into_iter().map(|s| (s.to_owned(), ()))));
-
-    for key in keys {
-        object.insert(key, ());
+    #[test]
+    fn test_string() {
+        let value = "foobar".to_owned();
+        assert_eq!(&to_vec(&value).unwrap()[..], b"ffoobar");
     }
-    let vec = to_vec(&object).unwrap();
-    assert_eq!(
-        vec![
-            166, 161, 97, 97, 246, 246, 161, 97, 98, 246, 246, 161, 97, 99, 246, 246, 161, 97, 100,
-            246, 246, 161, 98, 97, 97, 246, 246, 162, 97, 97, 246, 98, 97, 97, 246, 246
-        ],
-        vec
-    );
-    let test_object = from_slice(&vec[..]).unwrap();
-    assert_eq!(object, test_object);
-}
 
-#[test]
-fn test_float() {
-    let vec = to_vec(&12.3f64).unwrap();
-    assert_eq!(vec, b"\xfb@(\x99\x99\x99\x99\x99\x9a");
-}
-
-#[test]
-fn test_f32() {
-    let vec = to_vec(&4000.5f32).unwrap();
-    assert_eq!(vec, b"\xfa\x45\x7a\x08\x00");
-}
-
-#[test]
-fn test_infinity() {
-    let vec = to_vec(&::std::f64::INFINITY).unwrap();
-    assert_eq!(vec, b"\xf9|\x00");
-}
-
-#[test]
-fn test_neg_infinity() {
-    let vec = to_vec(&::std::f64::NEG_INFINITY).unwrap();
-    assert_eq!(vec, b"\xf9\xfc\x00");
-}
-
-#[test]
-fn test_nan() {
-    let vec = to_vec(&::std::f32::NAN).unwrap();
-    assert_eq!(vec, b"\xf9\x7e\x00");
-}
-
-#[test]
-fn test_integer() {
-    // u8
-    let vec = to_vec(&24).unwrap();
-    assert_eq!(vec, b"\x18\x18");
-    // i8
-    let vec = to_vec(&-5).unwrap();
-    assert_eq!(vec, b"\x24");
-    // i16
-    let vec = to_vec(&-300).unwrap();
-    assert_eq!(vec, b"\x39\x01\x2b");
-    // i32
-    let vec = to_vec(&-23567997).unwrap();
-    assert_eq!(vec, b"\x3a\x01\x67\x9e\x7c");
-    // u64
-    let vec = to_vec(&::std::u64::MAX).unwrap();
-    assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
-}
-
-#[test]
-fn test_self_describing() {
-    let mut vec = Vec::new();
-    {
-        let mut serializer = ser::Serializer::new(&mut vec);
-        serializer.self_describe().unwrap();
-        serializer.serialize_u64(9).unwrap();
+    #[test]
+    fn test_list() {
+        let value = vec![1, 2, 3];
+        assert_eq!(&to_vec(&value).unwrap()[..], b"\x83\x01\x02\x03");
     }
-    assert_eq!(vec, b"\xd9\xd9\xf7\x09");
 
-    let sd = ser::SerializerOptions {
-        self_describe: true,
-        ..Default::default()
-    };
-    let vec = sd.to_vec(&9).unwrap();
-    assert_eq!(vec, b"\xd9\xd9\xf7\x09");
-}
+    #[test]
+    fn test_object() {
+        let mut object = BTreeMap::new();
+        object.insert("a".to_owned(), "A".to_owned());
+        object.insert("b".to_owned(), "B".to_owned());
+        object.insert("c".to_owned(), "C".to_owned());
+        object.insert("d".to_owned(), "D".to_owned());
+        object.insert("e".to_owned(), "E".to_owned());
+        let vec = to_vec(&object).unwrap();
+        let test_object = from_slice(&vec[..]).unwrap();
+        assert_eq!(object, test_object);
+    }
 
-#[test]
-fn test_ip_addr() {
-    use std::net::Ipv4Addr;
+    #[test]
+    fn test_object_list_keys() {
+        let mut object = BTreeMap::new();
+        object.insert(vec![0i64], ());
+        object.insert(vec![100i64], ());
+        object.insert(vec![-1i64], ());
+        object.insert(vec![-2i64], ());
+        object.insert(vec![0i64, 0i64], ());
+        object.insert(vec![0i64, -1i64], ());
+        let vec = to_vec(&object).unwrap();
+        assert_eq!(
+            vec![
+                166, 129, 0, 246, 129, 24, 100, 246, 129, 32, 246, 129, 33, 246, 130, 0, 0, 246,
+                130, 0, 32, 246
+            ],
+            vec
+        );
+        let test_object = from_slice(&vec[..]).unwrap();
+        assert_eq!(object, test_object);
+    }
 
-    let addr = Ipv4Addr::new(8, 8, 8, 8);
-    let vec = to_vec(&addr).unwrap();
-    println!("{:?}", vec);
-    assert_eq!(vec.len(), 5);
-    let test_addr: Ipv4Addr = from_slice(&vec).unwrap();
-    assert_eq!(addr, test_addr);
-}
-
-/// Test all of CBOR's fixed-length byte string types
-#[test]
-fn test_byte_string() {
-    // Very short byte strings have 1-byte headers
-    let short = ByteBuf::from(vec![0, 1, 2, 255]);
-    let short_s = to_vec(&short).unwrap();
-    assert_eq!(&short_s[..], [0x44, 0, 1, 2, 255]);
-
-    // Encoding a slice should work the same as a vector
-    let short_slice_s = to_vec(&Bytes::from(&short[..])).unwrap();
-    assert_eq!(&short_slice_s[..], [0x44, 0, 1, 2, 255]);
-
-    // byte strings > 23 bytes have 2-byte headers
-    let medium = ByteBuf::from(vec![
-        0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 255,
-    ]);
-    let medium_s = to_vec(&medium).unwrap();
-    assert_eq!(
-        &medium_s[..],
-        [
-            0x58, 24, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-            22, 255
+    #[test]
+    fn test_object_object_keys() {
+        use std::iter::FromIterator;
+        let mut object = BTreeMap::new();
+        let keys = vec![
+            vec!["a"],
+            vec!["b"],
+            vec!["c"],
+            vec!["d"],
+            vec!["aa"],
+            vec!["a", "aa"],
         ]
-    );
+        .into_iter()
+        .map(|v| BTreeMap::from_iter(v.into_iter().map(|s| (s.to_owned(), ()))));
 
-    // byte strings > 256 bytes have 3-byte headers
-    let long_vec = (0..256).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
-    let long = ByteBuf::from(long_vec);
-    let long_s = to_vec(&long).unwrap();
-    assert_eq!(&long_s[0..3], [0x59, 1, 0]);
-    assert_eq!(&long_s[3..], &long[..]);
+        for key in keys {
+            object.insert(key, ());
+        }
+        let vec = to_vec(&object).unwrap();
+        assert_eq!(
+            vec![
+                166, 161, 97, 97, 246, 246, 161, 97, 98, 246, 246, 161, 97, 99, 246, 246, 161, 97,
+                100, 246, 246, 161, 98, 97, 97, 246, 246, 162, 97, 97, 246, 98, 97, 97, 246, 246
+            ],
+            vec
+        );
+        let test_object = from_slice(&vec[..]).unwrap();
+        assert_eq!(object, test_object);
+    }
 
-    // byte strings > 2^16 bytes have 5-byte headers
-    let very_long_vec = (0..65536).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
-    let very_long = ByteBuf::from(very_long_vec);
-    let very_long_s = to_vec(&very_long).unwrap();
-    assert_eq!(&very_long_s[0..5], [0x5a, 0, 1, 0, 0]);
-    assert_eq!(&very_long_s[5..], &very_long[..]);
+    #[test]
+    fn test_float() {
+        let vec = to_vec(&12.3f64).unwrap();
+        assert_eq!(vec, b"\xfb@(\x99\x99\x99\x99\x99\x9a");
+    }
 
-    // byte strings > 2^32 bytes have 9-byte headers, but they take too much RAM
-    // to test in Travis.
-}
+    #[test]
+    fn test_f32() {
+        let vec = to_vec(&4000.5f32).unwrap();
+        assert_eq!(vec, b"\xfa\x45\x7a\x08\x00");
+    }
 
-#[test]
-fn test_half() {
-    let vec = to_vec(&42.5f32).unwrap();
-    assert_eq!(vec, b"\xF9\x51\x50");
-    assert_eq!(from_slice::<f32>(&vec[..]).unwrap(), 42.5f32);
+    #[test]
+    fn test_infinity() {
+        let vec = to_vec(&::std::f64::INFINITY).unwrap();
+        assert_eq!(vec, b"\xf9|\x00");
+    }
+
+    #[test]
+    fn test_neg_infinity() {
+        let vec = to_vec(&::std::f64::NEG_INFINITY).unwrap();
+        assert_eq!(vec, b"\xf9\xfc\x00");
+    }
+
+    #[test]
+    fn test_nan() {
+        let vec = to_vec(&::std::f32::NAN).unwrap();
+        assert_eq!(vec, b"\xf9\x7e\x00");
+    }
+
+    #[test]
+    fn test_integer() {
+        // u8
+        let vec = to_vec(&24).unwrap();
+        assert_eq!(vec, b"\x18\x18");
+        // i8
+        let vec = to_vec(&-5).unwrap();
+        assert_eq!(vec, b"\x24");
+        // i16
+        let vec = to_vec(&-300).unwrap();
+        assert_eq!(vec, b"\x39\x01\x2b");
+        // i32
+        let vec = to_vec(&-23567997).unwrap();
+        assert_eq!(vec, b"\x3a\x01\x67\x9e\x7c");
+        // u64
+        let vec = to_vec(&::std::u64::MAX).unwrap();
+        assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
+    }
+
+    #[test]
+    fn test_self_describing() {
+        let mut vec = Vec::new();
+        {
+            let mut serializer = ser::Serializer::new(&mut vec);
+            serializer.self_describe().unwrap();
+            serializer.serialize_u64(9).unwrap();
+        }
+        assert_eq!(vec, b"\xd9\xd9\xf7\x09");
+
+        let sd = ser::SerializerOptions {
+            self_describe: true,
+            ..Default::default()
+        };
+        let vec = sd.to_vec(&9).unwrap();
+        assert_eq!(vec, b"\xd9\xd9\xf7\x09");
+    }
+
+    #[test]
+    fn test_ip_addr() {
+        use std::net::Ipv4Addr;
+
+        let addr = Ipv4Addr::new(8, 8, 8, 8);
+        let vec = to_vec(&addr).unwrap();
+        println!("{:?}", vec);
+        assert_eq!(vec.len(), 5);
+        let test_addr: Ipv4Addr = from_slice(&vec).unwrap();
+        assert_eq!(addr, test_addr);
+    }
+
+    /// Test all of CBOR's fixed-length byte string types
+    #[test]
+    fn test_byte_string() {
+        // Very short byte strings have 1-byte headers
+        let short = ByteBuf::from(vec![0, 1, 2, 255]);
+        let short_s = to_vec(&short).unwrap();
+        assert_eq!(&short_s[..], [0x44, 0, 1, 2, 255]);
+
+        // Encoding a slice should work the same as a vector
+        let short_slice_s = to_vec(&Bytes::from(&short[..])).unwrap();
+        assert_eq!(&short_slice_s[..], [0x44, 0, 1, 2, 255]);
+
+        // byte strings > 23 bytes have 2-byte headers
+        let medium = ByteBuf::from(vec![
+            0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 255,
+        ]);
+        let medium_s = to_vec(&medium).unwrap();
+        assert_eq!(
+            &medium_s[..],
+            [
+                0x58, 24, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                21, 22, 255
+            ]
+        );
+
+        // byte strings > 256 bytes have 3-byte headers
+        let long_vec = (0..256).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
+        let long = ByteBuf::from(long_vec);
+        let long_s = to_vec(&long).unwrap();
+        assert_eq!(&long_s[0..3], [0x59, 1, 0]);
+        assert_eq!(&long_s[3..], &long[..]);
+
+        // byte strings > 2^16 bytes have 5-byte headers
+        let very_long_vec = (0..65536).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
+        let very_long = ByteBuf::from(very_long_vec);
+        let very_long_s = to_vec(&very_long).unwrap();
+        assert_eq!(&very_long_s[0..5], [0x5a, 0, 1, 0, 0]);
+        assert_eq!(&very_long_s[5..], &very_long[..]);
+
+        // byte strings > 2^32 bytes have 9-byte headers, but they take too much RAM
+        // to test in Travis.
+    }
+
+    #[test]
+    fn test_half() {
+        let vec = to_vec(&42.5f32).unwrap();
+        assert_eq!(vec, b"\xF9\x51\x50");
+        assert_eq!(from_slice::<f32>(&vec[..]).unwrap(), 42.5f32);
+    }
 }

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -1,127 +1,131 @@
 #[macro_use]
 extern crate serde_derive;
 
-use std::u8;
+#[cfg(feature = "std")]
+mod std_tests {
+    use std::u8;
 
-use serde_bytes::ByteBuf;
+    use serde_bytes::ByteBuf;
 
-use serde_cbor::ser::{to_vec, to_vec_packed};
-use serde_cbor::{from_mut_slice, from_reader, from_slice};
+    use serde_cbor::ser::{to_vec, to_vec_packed};
+    use serde_cbor::{from_mut_slice, from_reader, from_slice};
 
-fn to_binary(s: &'static str) -> Vec<u8> {
-    assert!(s.len() % 2 == 0);
-    let mut b = Vec::with_capacity(s.len() / 2);
-    for i in 0..s.len() / 2 {
-        b.push(u8::from_str_radix(&s[i * 2..(i + 1) * 2], 16).unwrap());
+    fn to_binary(s: &'static str) -> Vec<u8> {
+        assert!(s.len() % 2 == 0);
+        let mut b = Vec::with_capacity(s.len() / 2);
+        for i in 0..s.len() / 2 {
+            b.push(u8::from_str_radix(&s[i * 2..(i + 1) * 2], 16).unwrap());
+        }
+        b
     }
-    b
-}
 
-macro_rules! testcase {
-    ($name:ident, f64, $expr:expr, $s:expr) => {
-        #[test]
-        fn $name() {
-            let expr: f64 = $expr;
-            let mut serialized = to_binary($s);
-            assert_eq!(to_vec(&expr).unwrap(), serialized);
-            let parsed: f64 = from_slice(&serialized[..]).unwrap();
-            if !expr.is_nan() {
-                assert_eq!(expr, parsed);
-            } else {
-                assert!(parsed.is_nan())
+    macro_rules! testcase {
+        ($name:ident, f64, $expr:expr, $s:expr) => {
+            #[test]
+            fn $name() {
+                let expr: f64 = $expr;
+                let mut serialized = to_binary($s);
+                assert_eq!(to_vec(&expr).unwrap(), serialized);
+                let parsed: f64 = from_slice(&serialized[..]).unwrap();
+                if !expr.is_nan() {
+                    assert_eq!(expr, parsed);
+                } else {
+                    assert!(parsed.is_nan())
+                }
+
+                let parsed: f64 = from_reader(&mut &serialized[..]).unwrap();
+                if !expr.is_nan() {
+                    assert_eq!(expr, parsed);
+                } else {
+                    assert!(parsed.is_nan())
+                }
+
+                let parsed: f64 = from_mut_slice(&mut serialized[..]).unwrap();
+                if !expr.is_nan() {
+                    assert_eq!(expr, parsed);
+                } else {
+                    assert!(parsed.is_nan())
+                }
             }
+        };
+        ($name:ident, $ty:ty, $expr:expr, $s:expr) => {
+            #[test]
+            fn $name() {
+                let expr: $ty = $expr;
+                let mut serialized = to_binary($s);
+                assert_eq!(to_vec(&expr).unwrap(), serialized, "serialization differs");
+                let parsed: $ty = from_slice(&serialized[..]).unwrap();
+                assert_eq!(parsed, expr, "parsed result differs");
+                let packed = &to_vec_packed(&expr).expect("serializing packed")[..];
+                let parsed_from_packed: $ty = from_slice(packed).expect("parsing packed");
+                assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
 
-            let parsed: f64 = from_reader(&mut &serialized[..]).unwrap();
-            if !expr.is_nan() {
-                assert_eq!(expr, parsed);
-            } else {
-                assert!(parsed.is_nan())
+                let parsed: $ty = from_reader(&mut &serialized[..]).unwrap();
+                assert_eq!(parsed, expr, "parsed result differs");
+                let mut packed = to_vec_packed(&expr).expect("serializing packed");
+                let parsed_from_packed: $ty =
+                    from_reader(&mut &packed[..]).expect("parsing packed");
+                assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
+
+                let parsed: $ty = from_mut_slice(&mut serialized[..]).unwrap();
+                assert_eq!(parsed, expr, "parsed result differs");
+                let parsed_from_packed: $ty =
+                    from_mut_slice(&mut packed[..]).expect("parsing packed");
+                assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
             }
+        };
+    }
 
-            let parsed: f64 = from_mut_slice(&mut serialized[..]).unwrap();
-            if !expr.is_nan() {
-                assert_eq!(expr, parsed);
-            } else {
-                assert!(parsed.is_nan())
-            }
-        }
-    };
-    ($name:ident, $ty:ty, $expr:expr, $s:expr) => {
-        #[test]
-        fn $name() {
-            let expr: $ty = $expr;
-            let mut serialized = to_binary($s);
-            assert_eq!(to_vec(&expr).unwrap(), serialized, "serialization differs");
-            let parsed: $ty = from_slice(&serialized[..]).unwrap();
-            assert_eq!(parsed, expr, "parsed result differs");
-            let packed = &to_vec_packed(&expr).expect("serializing packed")[..];
-            let parsed_from_packed: $ty = from_slice(packed).expect("parsing packed");
-            assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
+    testcase!(test_bool_false, bool, false, "f4");
+    testcase!(test_bool_true, bool, true, "f5");
+    testcase!(test_isize_neg_256, isize, -256, "38ff");
+    testcase!(test_isize_neg_257, isize, -257, "390100");
+    testcase!(test_isize_255, isize, 255, "18ff");
+    testcase!(test_i8_5, i8, 5, "05");
+    testcase!(test_i8_23, i8, 23, "17");
+    testcase!(test_i8_24, i8, 24, "1818");
+    testcase!(test_i8_neg_128, i8, -128, "387f");
+    testcase!(test_u32_98745874, u32, 98745874, "1a05e2be12");
+    testcase!(test_f32_1234_point_5, f32, 1234.5, "fa449a5000");
+    testcase!(test_f64_12345_point_6, f64, 12345.6, "fb40c81ccccccccccd");
+    testcase!(test_f64_nan, f64, ::std::f64::NAN, "f97e00");
+    testcase!(test_f64_infinity, f64, ::std::f64::INFINITY, "f97c00");
+    testcase!(test_f64_neg_infinity, f64, -::std::f64::INFINITY, "f9fc00");
+    testcase!(test_char_null, char, '\x00', "6100");
+    testcase!(test_char_broken_heart, char, '💔', "64f09f9294");
+    testcase!(
+        test_str_pangram_de,
+        String,
+        "aâø↓é".to_owned(),
+        "6a61c3a2c3b8e28693c3a9"
+    );
+    testcase!(test_bytes, ByteBuf, b"\x00\xab".to_vec().into(), "4200ab");
+    testcase!(test_unit, (), (), "f6");
 
-            let parsed: $ty = from_reader(&mut &serialized[..]).unwrap();
-            assert_eq!(parsed, expr, "parsed result differs");
-            let mut packed = to_vec_packed(&expr).expect("serializing packed");
-            let parsed_from_packed: $ty = from_reader(&mut &packed[..]).expect("parsing packed");
-            assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct UnitStruct;
+    testcase!(test_unit_struct, UnitStruct, UnitStruct, "f6");
 
-            let parsed: $ty = from_mut_slice(&mut serialized[..]).unwrap();
-            assert_eq!(parsed, expr, "parsed result differs");
-            let parsed_from_packed: $ty = from_mut_slice(&mut packed[..]).expect("parsing packed");
-            assert_eq!(parsed_from_packed, expr, "packed roundtrip fail");
-        }
-    };
-}
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct NewtypeStruct(bool);
+    testcase!(
+        test_newtype_struct,
+        NewtypeStruct,
+        NewtypeStruct(true),
+        "f5"
+    );
 
-testcase!(test_bool_false, bool, false, "f4");
-testcase!(test_bool_true, bool, true, "f5");
-testcase!(test_isize_neg_256, isize, -256, "38ff");
-testcase!(test_isize_neg_257, isize, -257, "390100");
-testcase!(test_isize_255, isize, 255, "18ff");
-testcase!(test_i8_5, i8, 5, "05");
-testcase!(test_i8_23, i8, 23, "17");
-testcase!(test_i8_24, i8, 24, "1818");
-testcase!(test_i8_neg_128, i8, -128, "387f");
-testcase!(test_u32_98745874, u32, 98745874, "1a05e2be12");
-testcase!(test_f32_1234_point_5, f32, 1234.5, "fa449a5000");
-testcase!(test_f64_12345_point_6, f64, 12345.6, "fb40c81ccccccccccd");
-testcase!(test_f64_nan, f64, ::std::f64::NAN, "f97e00");
-testcase!(test_f64_infinity, f64, ::std::f64::INFINITY, "f97c00");
-testcase!(test_f64_neg_infinity, f64, -::std::f64::INFINITY, "f9fc00");
-testcase!(test_char_null, char, '\x00', "6100");
-testcase!(test_char_broken_heart, char, '💔', "64f09f9294");
-testcase!(
-    test_str_pangram_de,
-    String,
-    "aâø↓é".to_owned(),
-    "6a61c3a2c3b8e28693c3a9"
-);
-testcase!(test_bytes, ByteBuf, b"\x00\xab".to_vec().into(), "4200ab");
-testcase!(test_unit, (), (), "f6");
+    testcase!(test_option_none, Option<u8>, None, "f6");
+    testcase!(test_option_some, Option<u8>, Some(42), "182a");
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct UnitStruct;
-testcase!(test_unit_struct, UnitStruct, UnitStruct, "f6");
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct Person {
+        name: String,
+        year_of_birth: u16,
+        profession: Option<String>,
+    }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct NewtypeStruct(bool);
-testcase!(
-    test_newtype_struct,
-    NewtypeStruct,
-    NewtypeStruct(true),
-    "f5"
-);
-
-testcase!(test_option_none, Option<u8>, None, "f6");
-testcase!(test_option_some, Option<u8>, Some(42), "182a");
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct Person {
-    name: String,
-    year_of_birth: u16,
-    profession: Option<String>,
-}
-
-testcase!(test_person_struct,
+    testcase!(test_person_struct,
     Person,
     Person {
         name: "Grace Hopper".to_string(),
@@ -130,15 +134,15 @@ testcase!(test_person_struct,
     },
     "a3646e616d656c477261636520486f707065726a70726f66657373696f6e72636f6d707574657220736369656e746973746d796561725f6f665f6269727468190772");
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-struct OptionalPerson {
-    name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    year_of_birth: Option<u16>,
-    profession: Option<String>,
-}
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct OptionalPerson {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        year_of_birth: Option<u16>,
+        profession: Option<String>,
+    }
 
-testcase!(test_optional_person_struct,
+    testcase!(test_optional_person_struct,
     OptionalPerson,
     OptionalPerson {
         name: "Grace Hopper".to_string(),
@@ -147,25 +151,26 @@ testcase!(test_optional_person_struct,
     },
     "a2646e616d656c477261636520486f707065726a70726f66657373696f6e72636f6d707574657220736369656e74697374");
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-enum Color {
-    Red,
-    Blue,
-    Yellow,
-    Other(u64),
-    Alpha(u64, u8),
-}
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    enum Color {
+        Red,
+        Blue,
+        Yellow,
+        Other(u64),
+        Alpha(u64, u8),
+    }
 
-testcase!(test_color_enum, Color, Color::Blue, "64426c7565");
-testcase!(
-    test_color_enum_transparent,
-    Color,
-    Color::Other(42),
-    "82654f74686572182a"
-);
-testcase!(
-    test_color_enum_with_alpha,
-    Color,
-    Color::Alpha(234567, 60),
-    "8365416c7068611a00039447183c"
-);
+    testcase!(test_color_enum, Color, Color::Blue, "64426c7565");
+    testcase!(
+        test_color_enum_transparent,
+        Color,
+        Color::Other(42),
+        "82654f74686572182a"
+    );
+    testcase!(
+        test_color_enum_with_alpha,
+        Color,
+        Color::Alpha(234567, 60),
+        "8365416c7068611a00039447183c"
+    );
+}

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,74 +1,78 @@
 #[macro_use]
 extern crate serde_derive;
-use serde_cbor;
 
-use std::collections::BTreeMap;
+#[cfg(feature = "std")]
+mod std_tests {
+    use serde_cbor;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-struct TupleStruct(String, i32, u64);
+    use std::collections::BTreeMap;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-struct UnitStruct;
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    struct TupleStruct(String, i32, u64);
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-struct Struct<'a> {
-    tuple_struct: TupleStruct,
-    tuple: (String, f32, f64),
-    map: BTreeMap<String, String>,
-    bytes: &'a [u8],
-    array: Vec<String>,
-    unit_array: Vec<UnitStruct>,
-}
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    struct UnitStruct;
 
-use serde_cbor::Value;
-use std::iter::FromIterator;
-
-#[test]
-fn serde() {
-    let tuple_struct = TupleStruct(format!("test"), -60, 3000);
-
-    let tuple = (format!("hello"), -50.0040957, -12.094635556478);
-
-    let map = BTreeMap::from_iter(
-        [
-            (format!("key1"), format!("value1")),
-            (format!("key2"), format!("value2")),
-            (format!("key3"), format!("value3")),
-            (format!("key4"), format!("value4")),
-        ]
-        .into_iter()
-        .cloned(),
-    );
-
-    let bytes = b"test byte string";
-
-    let array = vec![format!("one"), format!("two"), format!("three")];
-    let unit_array = vec![UnitStruct, UnitStruct, UnitStruct];
-
-    let data = Struct {
-        tuple_struct,
-        tuple,
-        map,
-        bytes,
-        array,
-        unit_array,
-    };
-
-    let value = serde_cbor::to_value(data.clone()).unwrap();
-    println!("{:?}", value);
-
-    let data_ser = serde_cbor::to_vec(&value).unwrap();
-    let data_de_value: Value = serde_cbor::from_slice(&data_ser).unwrap();
-
-    for ((k1, v1), (k2, v2)) in value
-        .as_object()
-        .unwrap()
-        .iter()
-        .zip(data_de_value.as_object().unwrap().iter())
-    {
-        assert_eq!(k1, k2);
-        assert_eq!(v1, v2);
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    struct Struct<'a> {
+        tuple_struct: TupleStruct,
+        tuple: (String, f32, f64),
+        map: BTreeMap<String, String>,
+        bytes: &'a [u8],
+        array: Vec<String>,
+        unit_array: Vec<UnitStruct>,
     }
 
-    assert_eq!(value, data_de_value);
+    use serde_cbor::Value;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn serde() {
+        let tuple_struct = TupleStruct(format!("test"), -60, 3000);
+
+        let tuple = (format!("hello"), -50.0040957, -12.094635556478);
+
+        let map = BTreeMap::from_iter(
+            [
+                (format!("key1"), format!("value1")),
+                (format!("key2"), format!("value2")),
+                (format!("key3"), format!("value3")),
+                (format!("key4"), format!("value4")),
+            ]
+            .into_iter()
+            .cloned(),
+        );
+
+        let bytes = b"test byte string";
+
+        let array = vec![format!("one"), format!("two"), format!("three")];
+        let unit_array = vec![UnitStruct, UnitStruct, UnitStruct];
+
+        let data = Struct {
+            tuple_struct,
+            tuple,
+            map,
+            bytes,
+            array,
+            unit_array,
+        };
+
+        let value = serde_cbor::to_value(data.clone()).unwrap();
+        println!("{:?}", value);
+
+        let data_ser = serde_cbor::to_vec(&value).unwrap();
+        let data_de_value: Value = serde_cbor::from_slice(&data_ser).unwrap();
+
+        for ((k1, v1), (k2, v2)) in value
+            .as_object()
+            .unwrap()
+            .iter()
+            .zip(data_de_value.as_object().unwrap().iter())
+        {
+            assert_eq!(k1, k2);
+            assert_eq!(v1, v2);
+        }
+
+        assert_eq!(value, data_de_value);
+    }
 }


### PR DESCRIPTION
Resolves #79.

This builds on the efforts of @chrysn to implement `no_std` support. It also introduces a few things I needed when developing an embedded application based on this crate.

# Notable changes
* Adds a default `std` feature that can be disabled for `no_std` support
* Introduction of a local `Write` trait similar to the existing `Read`, as `std::io::Write` is not available in core.
* `SliceReadFixed`, similar to `SliceRead` but using a mutable slice as a scratch buffer. This is useful in `no_std` environments when the input slice is immutable (so `MutSliceRead` is off the table).
* A new feature `unsealed_read_write` (disabled by default) becomes available, which unseals the `Read` and `Write` trait. This is useful in `no_std` to implement `Read` on a custom `File` type.

# Public API Changes
the methods `Serializer::new`, `Serializer::packed` and `Serializer::new_with_options` now take a writer that implements the local `Write` trait instead of `std::io::Write`. An `std::io::Write` now needs to be wrapped in an `IoWrite` to be passed to any of these functions. In most cases this should not be a problem, as the types for `serde_cbor::to_vec` and `serde_cbor::to_writer` still take `std::io::Write`.

One possible alternative would be to make `new, packed, new_with_options` still take `std::io::Write` and add similar methods for `Write`.

# Papercuts
* In `no_std` mode, deserialiation and serialiation errors are mapped to a generic error that removes all context.
* The `Read` and `Write` traits are duplicated for the `unsealed_read_write` feature, this is not very DRY.