### PR TITLE
Update Error impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -97,14 +97,7 @@ impl Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self.0.code {
-            ErrorCode::Io(ref err) => error::Error::description(err),
-            _ => "CBOR error",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.0.code {
             ErrorCode::Io(ref err) => Some(err),
             _ => None,


### PR DESCRIPTION
Remove the implementation of the now-deprecated description method, and
implement source rather than cause.

Closes #94