### PR TITLE
Support deserializing from mixed slices

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -44,6 +44,34 @@ where
     Ok(value)
 }
 
+/// Decodes a value from CBOR data in a longer than necessary slice.
+///
+/// This is used when mixed data are packed together
+///
+/// # Examples
+///
+/// Deserialize a `String`
+///
+/// ```
+/// # use serde_cbor::de;
+/// let v: Vec<u8> = vec![0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72,
+///                       0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72];
+/// let (rest, value): (&[u8], String) = de::from_slice_stream(&v[..]).unwrap();
+/// assert_eq!(value, "foobar");
+/// assert_eq!(rest, &[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+/// let (rest, value): (&[u8], String) = de::from_slice_stream(rest).unwrap();
+/// assert_eq!(value, "foobar");
+/// assert_eq!(rest, &[]);
+/// ```
+pub fn from_slice_stream<'a, T>(slice: &'a [u8]) -> Result<(&'a[u8], T)>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut deserializer = Deserializer::from_slice(slice);
+    let value = de::Deserialize::deserialize(&mut deserializer)?;
+    Ok((&slice[deserializer.read.index..], value))
+}
+
 /// Decode a value from CBOR data in a mutable slice.
 ///
 /// This can be used in analogy to `from_slice`. Unlike `from_slice`, this will use the slice's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub mod ser;
 pub mod value;
 
 #[doc(inline)]
-pub use de::{from_slice, from_mut_slice, from_reader, Deserializer, StreamDeserializer};
+pub use de::{from_slice, from_mut_slice, from_reader, Deserializer, StreamDeserializer, from_slice_stream};
 #[doc(inline)]
 pub use ser::{to_writer, to_vec, to_vec_with_options, Serializer, SerializerOptions};
 #[doc(inline)]

--- a/src/read.rs
+++ b/src/read.rs
@@ -225,7 +225,8 @@ where
 pub struct SliceRead<'a> {
     slice: &'a [u8],
     scratch: Vec<u8>,
-    index: usize,
+    /// Reader position in the slice
+    pub index: usize,
 }
 
 impl<'a> SliceRead<'a> {


### PR DESCRIPTION
When trying to parse fido2 (ctap2) responses from token,
slices are packed together, cbor encoded data may be followed
by other type of data.

This patch introduces a new `from_slice_stream` method that would
return the rest of the buffer instead of raising an error.