### PR TITLE
Support deserializing from mixed slices.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -15,6 +15,7 @@ use crate::error::{Error, ErrorCode, Result};
 use crate::read::EitherLifetime;
 #[cfg(feature = "unsealed_read_write")]
 pub use crate::read::EitherLifetime;
+use crate::read::Offset;
 #[cfg(feature = "std")]
 pub use crate::read::{IoRead, SliceRead};
 pub use crate::read::{MutSliceRead, Read, SliceReadFixed};
@@ -793,6 +794,17 @@ where
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string unit
         unit_struct seq tuple tuple_struct map struct identifier ignored_any
         bytes byte_buf
+    }
+}
+
+impl<R> Deserializer<R>
+where
+    R: Offset,
+{
+    /// Return the current offset in the reader
+    #[inline]
+    pub fn byte_offset(&self) -> usize {
+        self.read.byte_offset()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,25 @@
 //! # }
 //! ```
 //!
+//! Deserializing data in the middle of a slice
+//! ```
+//! # extern crate serde_cbor;
+//! use serde_cbor::Deserializer;
+//!
+//! # fn main() {
+//! let data: Vec<u8> = vec![
+//!     0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x66, 0x66, 0x6f, 0x6f, 0x62,
+//!     0x61, 0x72,
+//! ];
+//! let mut deserializer = Deserializer::from_slice(&data);
+//! let value: &str = serde::de::Deserialize::deserialize(&mut deserializer)
+//!     .unwrap();
+//! let rest = &data[deserializer.byte_offset()..];
+//! assert_eq!(value, "foobar");
+//! assert_eq!(rest, &[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+//! # }
+//! ```
+//!
 //! # Limitations
 //!
 //! While Serde CBOR strives to support all features of Serde and CBOR

--- a/src/read.rs
+++ b/src/read.rs
@@ -113,6 +113,11 @@ pub trait Read<'de> {
     fn offset(&self) -> u64;
 }
 
+/// Represents a reader that can return its current position
+pub trait Offset {
+    fn byte_offset(&self) -> usize;
+}
+
 /// Represents a buffer with one of two lifetimes.
 pub enum EitherLifetime<'short, 'long> {
     /// The short lifetime
@@ -303,6 +308,14 @@ impl<'a> SliceRead<'a> {
                 self.slice.len() as u64,
             )),
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Offset for SliceRead<'a> {
+    #[inline]
+    fn byte_offset(&self) -> usize {
+        self.index
     }
 }
 


### PR DESCRIPTION
When trying to parse fido2 (ctap2) responses from token,
slices are packed together, cbor encoded data may be followed
by other type of data.

This patch introduces a new `byte_offset` method that would
return the position of the reader.

Based on suggestions of @dtolnay. Superseed #100.