### PR TITLE
fixup serde_bytes dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ maintenance = { status = "actively-developed" }
 byteorder = { version = "1.0.0", default-features = false }
 half = "1.2.0"
 serde = { version = "1.0.14", default-features = false }
+serde_bytes = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]
-serde_bytes = { version = "0.10", default-features = false }
 serde_derive = { version = "1.0.14", default-features = false }
 
 [features]


### PR DESCRIPTION
When a crate depends on serde_cbor master, the following error is
thrown:
```
error: failed to select a version for `serde_cbor`.
    ... required by package `authenticator v0.2.4 (/home/baloo/work/dev/authenticator-rs)`
versions that meet the requirements `*` are: 0.9.0

the package `authenticator` depends on `serde_cbor`, with features: `serde_bytes` but `serde_cbor` does not have these features.

failed to select a version for `serde_cbor` which could resolve this conflict
```

I believe serde_bytes should not be a dev-dependency but an optional
dependency instead.