### PR TITLE
Add byte_offset() method for StreamDeserializer.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1140,6 +1140,18 @@ where
     }
 }
 
+impl<'de, R, T> StreamDeserializer<'de, R, T>
+where
+    R: Offset,
+    T: de::Deserialize<'de>,
+{
+    /// Return the current offset in the reader
+    #[inline]
+    pub fn byte_offset(&self) -> usize {
+        self.de.byte_offset()
+    }
+}
+
 impl<'de, R, T> Iterator for StreamDeserializer<'de, R, T>
 where
     R: Read<'de>,


### PR DESCRIPTION
When iterating over the input stream during deserializtion, we have no way to get the data size in the stream. This function can help us a little about that.
 #110 