### PR TITLE
Remove serde-bytes dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,9 @@ half = "1.2.0"
 serde = { version = "1.0.14", default-features = false }
 
 [dev-dependencies]
-serde_bytes = { version = "0.10", default-features = false }
 serde_derive = { version = "1.0.14", default-features = false }
 
 [features]
 default = ["std"]
-std = ["serde/std", "serde_bytes/std" ]
+std = ["serde/std" ]
 unsealed_read_write = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,25 +126,6 @@
 //! assert_eq!(encoded.unwrap().len(), 103);
 //! ```
 //!
-//! Serializing a `Vec` as a specialized byte string uses about 2x less RAM and
-//! 100x less CPU time than serializing it as an array.
-//!
-//! ```rust
-//! # extern crate serde_bytes;
-//! # extern crate serde_cbor;
-//! use std::collections::BTreeMap;
-//! use serde_bytes::ByteBuf;
-//! use serde_cbor::to_vec;
-//!
-//! # fn main() {
-//! let data: Vec<u8> = vec![0, 1, 255];
-//! let serialized_array = to_vec(&data).unwrap();
-//! let byte_buf = ByteBuf::from(data);
-//! let serialized_byte_string = to_vec(&byte_buf).unwrap();
-//! assert!(serialized_byte_string.len() < serialized_array.len());
-//! # }
-//! ```
-//!
 //! Deserializing data in the middle of a slice
 //! ```
 //! # extern crate serde_cbor;

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -45,11 +45,10 @@ fn test_indefinite_object() {
 
 #[cfg(feature = "std")]
 mod std_tests {
-    use serde_bytes::ByteBuf;
     use std::collections::BTreeMap;
 
     use serde::de as serde_de;
-    use serde_cbor::{de, error, from_reader, to_vec, Deserializer, ObjectKey, Value};
+    use serde_cbor::{de, error, to_vec, Deserializer, ObjectKey, Value};
 
     #[test]
     fn test_string1() {
@@ -374,18 +373,6 @@ mod std_tests {
                 .into_iter::<Value>();
             assert!(it.next().unwrap().unwrap_err().is_eof());
         }
-    }
-
-    #[test]
-    fn test_large_bytes() {
-        let expected = (0..2 * 1024 * 1024)
-            .map(|i| (i * 7) as u8)
-            .collect::<Vec<_>>();
-        let expected = ByteBuf::from(expected);
-        let v = to_vec(&expected).unwrap();
-
-        let actual = from_reader(&v[..]).unwrap();
-        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -209,7 +209,9 @@ mod std_tests {
         // Very short byte strings have 1-byte headers
         let short = vec![0, 1, 2, 255];
         let mut short_s = Vec::new();
-        serde_cbor::Serializer::new(&mut short_s).serialize_bytes(&short).unwrap();
+        serde_cbor::Serializer::new(&mut short_s)
+            .serialize_bytes(&short)
+            .unwrap();
         assert_eq!(&short_s[..], [0x44, 0, 1, 2, 255]);
 
         // byte strings > 23 bytes have 2-byte headers
@@ -217,7 +219,9 @@ mod std_tests {
             0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 255,
         ];
         let mut medium_s = Vec::new();
-        serde_cbor::Serializer::new(&mut medium_s).serialize_bytes(&medium).unwrap();
+        serde_cbor::Serializer::new(&mut medium_s)
+            .serialize_bytes(&medium)
+            .unwrap();
         assert_eq!(
             &medium_s[..],
             [
@@ -229,14 +233,18 @@ mod std_tests {
         // byte strings > 256 bytes have 3-byte headers
         let long_vec = (0..256).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
         let mut long_s = Vec::new();
-        serde_cbor::Serializer::new(&mut long_s).serialize_bytes(&long_vec).unwrap();
+        serde_cbor::Serializer::new(&mut long_s)
+            .serialize_bytes(&long_vec)
+            .unwrap();
         assert_eq!(&long_s[0..3], [0x59, 1, 0]);
         assert_eq!(&long_s[3..], &long_vec[..]);
 
         // byte strings > 2^16 bytes have 5-byte headers
         let very_long_vec = (0..65536).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
         let mut very_long_s = Vec::new();
-        serde_cbor::Serializer::new(&mut very_long_s).serialize_bytes(&very_long_vec).unwrap();
+        serde_cbor::Serializer::new(&mut very_long_s)
+            .serialize_bytes(&very_long_vec)
+            .unwrap();
         assert_eq!(&very_long_s[0..5], [0x5a, 0, 1, 0, 0]);
         assert_eq!(&very_long_s[5..], &very_long_vec[..]);
 

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -44,7 +44,6 @@ fn serialize_and_compare<T: Serialize>(value: T, expected: &[u8]) {
 #[cfg(feature = "std")]
 mod std_tests {
     use serde::Serializer;
-    use serde_bytes::{ByteBuf, Bytes};
     use serde_cbor::ser;
     use serde_cbor::{from_slice, to_vec};
     use std::collections::BTreeMap;
@@ -208,19 +207,17 @@ mod std_tests {
     #[test]
     fn test_byte_string() {
         // Very short byte strings have 1-byte headers
-        let short = ByteBuf::from(vec![0, 1, 2, 255]);
-        let short_s = to_vec(&short).unwrap();
+        let short = vec![0, 1, 2, 255];
+        let mut short_s = Vec::new();
+        serde_cbor::Serializer::new(&mut short_s).serialize_bytes(&short).unwrap();
         assert_eq!(&short_s[..], [0x44, 0, 1, 2, 255]);
 
-        // Encoding a slice should work the same as a vector
-        let short_slice_s = to_vec(&Bytes::from(&short[..])).unwrap();
-        assert_eq!(&short_slice_s[..], [0x44, 0, 1, 2, 255]);
-
         // byte strings > 23 bytes have 2-byte headers
-        let medium = ByteBuf::from(vec![
+        let medium = vec![
             0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 255,
-        ]);
-        let medium_s = to_vec(&medium).unwrap();
+        ];
+        let mut medium_s = Vec::new();
+        serde_cbor::Serializer::new(&mut medium_s).serialize_bytes(&medium).unwrap();
         assert_eq!(
             &medium_s[..],
             [
@@ -231,17 +228,17 @@ mod std_tests {
 
         // byte strings > 256 bytes have 3-byte headers
         let long_vec = (0..256).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
-        let long = ByteBuf::from(long_vec);
-        let long_s = to_vec(&long).unwrap();
+        let mut long_s = Vec::new();
+        serde_cbor::Serializer::new(&mut long_s).serialize_bytes(&long_vec).unwrap();
         assert_eq!(&long_s[0..3], [0x59, 1, 0]);
-        assert_eq!(&long_s[3..], &long[..]);
+        assert_eq!(&long_s[3..], &long_vec[..]);
 
         // byte strings > 2^16 bytes have 5-byte headers
         let very_long_vec = (0..65536).map(|i| (i & 0xFF) as u8).collect::<Vec<_>>();
-        let very_long = ByteBuf::from(very_long_vec);
-        let very_long_s = to_vec(&very_long).unwrap();
+        let mut very_long_s = Vec::new();
+        serde_cbor::Serializer::new(&mut very_long_s).serialize_bytes(&very_long_vec).unwrap();
         assert_eq!(&very_long_s[0..5], [0x5a, 0, 1, 0, 0]);
-        assert_eq!(&very_long_s[5..], &very_long[..]);
+        assert_eq!(&very_long_s[5..], &very_long_vec[..]);
 
         // byte strings > 2^32 bytes have 9-byte headers, but they take too much RAM
         // to test in Travis.

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -5,8 +5,6 @@ extern crate serde_derive;
 mod std_tests {
     use std::u8;
 
-    use serde_bytes::ByteBuf;
-
     use serde_cbor::ser::{to_vec, to_vec_packed};
     use serde_cbor::{from_mut_slice, from_reader, from_slice};
 
@@ -103,7 +101,6 @@ mod std_tests {
         "aâø↓é".to_owned(),
         "6a61c3a2c3b8e28693c3a9"
     );
-    testcase!(test_bytes, ByteBuf, b"\x00\xab".to_vec().into(), "4200ab");
     testcase!(test_unit, (), (), "f6");
 
     #[derive(Debug, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
It caused build problems because of optional features.
Change some tests for byte strings.
Remove failing tests I believe to be redundant.

cc @baloo 