### PR TITLE
Serialize enums as maps by default

### DIFF
--- a/tests/bennofs.rs
+++ b/tests/bennofs.rs
@@ -49,7 +49,7 @@ mod std_tests {
 fn test() {
     let mut slice = [0u8; 64];
     let writer = SliceWrite::new(&mut slice);
-    let mut serializer = Serializer::packed(writer);
+    let mut serializer = Serializer::new(writer).packed_format();
     EXAMPLE.serialize(&mut serializer).unwrap();
     let writer = serializer.into_inner();
     let end = writer.bytes_written();

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -182,13 +182,6 @@ mod std_tests {
             serializer.serialize_u64(9).unwrap();
         }
         assert_eq!(vec, b"\xd9\xd9\xf7\x09");
-
-        let sd = ser::SerializerOptions {
-            self_describe: true,
-            ..Default::default()
-        };
-        let vec = sd.to_vec(&9).unwrap();
-        assert_eq!(vec, b"\xd9\xd9\xf7\x09");
     }
 
     #[test]

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -167,13 +167,13 @@ mod std_tests {
         test_color_enum_transparent,
         Color,
         Color::Other(42),
-        "82654f74686572182a"
+        "a1654f74686572182a"
     );
     testcase!(
         test_color_enum_with_alpha,
         Color,
         Color::Alpha(234567, 60),
-        "8365416c7068611a00039447183c"
+        "a165416c706861821a00039447183c"
     );
     testcase!(test_i128_a, i128, -1i128, "20");
     testcase!(


### PR DESCRIPTION
This matches other serde formats.
Directly set options on Serializer.
Remove rarely used to_* methods.

Closes #85 