### PR TITLE
no-std: Fixup warning on dead code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -130,8 +130,6 @@ impl Error {
             ErrorCode::Message => Category::Data,
             #[cfg(feature = "std")]
             ErrorCode::Io(_) => Category::Io,
-            #[cfg(not(feature = "std"))]
-            ErrorCode::Io => Category::Io,
             ErrorCode::ScratchTooSmall => Category::Io,
             ErrorCode::EofWhileParsingValue
             | ErrorCode::EofWhileParsingArray
@@ -267,8 +265,6 @@ pub(crate) enum ErrorCode {
     Message,
     #[cfg(feature = "std")]
     Io(io::Error),
-    #[cfg(not(feature = "std"))]
-    Io,
     ScratchTooSmall,
     EofWhileParsingValue,
     EofWhileParsingArray,
@@ -292,8 +288,6 @@ impl fmt::Display for ErrorCode {
             ErrorCode::Message => f.write_str("Unknown error"),
             #[cfg(feature = "std")]
             ErrorCode::Io(ref err) => fmt::Display::fmt(err, f),
-            #[cfg(not(feature = "std"))]
-            ErrorCode::Io => f.write_str("Unknown I/O error"),
             ErrorCode::ScratchTooSmall => f.write_str("Scratch buffer too small"),
             ErrorCode::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
             ErrorCode::EofWhileParsingArray => f.write_str("EOF while parsing an array"),


### PR DESCRIPTION
When building cbor with no-std, I get the following warning:
```
warning: variant is never constructed: `Io`
   --> cbor/src/error.rs:271:5
    |
271 |     Io,
    |     ^^
    |
    = note: #[warn(dead_code)] on by default
```
