### PR TITLE
feat: implement simple tagging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ maintenance = { status = "actively-developed" }
 byteorder = { version = "1.0.0", default-features = false }
 half = "1.2.0"
 serde = { version = "1.0.14", default-features = false }
+serde_derive = { version = "1.0.14", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0.14", default-features = false }
@@ -31,3 +32,4 @@ default = ["std"]
 alloc = ["serde/alloc"]
 std = ["serde/std" ]
 unsealed_read_write = []
+tags = ["serde_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,10 +267,16 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "tags")]
+#[macro_use]
+extern crate serde_derive;
+
 pub mod de;
 pub mod error;
 mod read;
 pub mod ser;
+#[cfg(feature = "tags")]
+mod tag;
 mod write;
 
 #[cfg(feature = "std")]
@@ -308,3 +314,6 @@ pub use crate::ser::to_writer;
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use crate::value::Value;
+
+#[cfg(feature = "tags")]
+pub use tag::EncodeCborTag;

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,0 +1,40 @@
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+/// Wrapper struct to handle encoding Cbor semantic tags.
+#[derive(Deserialize)]
+pub struct EncodeCborTag<T: Serialize> {
+    __cbor_tag_ser_tag: u64,
+    __cbor_tag_ser_data: T,
+}
+
+impl<T: Serialize> EncodeCborTag<T> {
+    /// Constructs a new `EncodeCborTag`, to wrap your type in a tag.
+    pub fn new(tag: u64, value: T) -> Self {
+        EncodeCborTag {
+            __cbor_tag_ser_tag: tag,
+            __cbor_tag_ser_data: value,
+        }
+    }
+
+    /// Returns the tag.
+    pub fn tag(&self) -> u64 {
+        self.__cbor_tag_ser_tag
+    }
+
+    /// Returns the inner value, consuming the wrapper.
+    pub fn value(self) -> T {
+        self.__cbor_tag_ser_data
+    }
+}
+
+impl<T: Serialize> Serialize for EncodeCborTag<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("EncodeCborTag", 2)?;
+        state.serialize_field("__cbor_tag_ser_tag", &self.__cbor_tag_ser_tag)?;
+        state.serialize_field("__cbor_tag_ser_data", &self.__cbor_tag_ser_data)?;
+        state.end()
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -51,6 +51,8 @@ pub enum Value {
     /// to establish canonical order may be slow and therefore insertion
     /// and retrieval of values will be slow too.
     Map(BTreeMap<Value, Value>),
+    /// Semantic Tag
+    Tag(u64),
     // The hidden variant allows the enum to be extended
     // with variants for tags and simple values.
     #[doc(hidden)]
@@ -147,6 +149,7 @@ impl Value {
             Text(_) => 3,
             Array(_) => 4,
             Map(_) => 5,
+            Tag(_) => 6,
             __Hidden => unreachable!(),
         }
     }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -220,6 +220,21 @@ mod std_tests {
         assert_eq!(value.unwrap(), Value::Float(100000.0));
     }
 
+    #[cfg(feature = "tags")]
+    #[test]
+    fn test_self_describing() {
+        let value: error::Result<Value> =
+            de::from_slice(&[0xd9, 0xd9, 0xf7, 0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+        assert_eq!(
+            value.unwrap(),
+            Value::Array(vec![
+                Value::Integer(55799),
+                Value::Text("foobar".to_owned())
+            ])
+        );
+    }
+
+    #[cfg(not(feature = "tags"))]
     #[test]
     fn test_self_describing() {
         let value: error::Result<Value> =

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -303,6 +303,13 @@ mod std_tests {
 
         assert_eq!(res, value);
 
+        // Serialize via `Value`
+
+        let value = MyTaggedValue(vec![1, 2, 3]);
+        let bytes = b"\xC9\x83\x01\x02\x03";
+        let encoded = to_vec(&serde_cbor::value::to_value(value).unwrap()).unwrap();
+        assert_eq!(&encoded[..], bytes);
+
         // Deserialize tag into tuple
         let res: (u64, (usize, usize, usize)) =
             serde_cbor::de::from_slice_with_scratch(bytes, &mut []).unwrap();


### PR DESCRIPTION
Mostly putting this here for visibility, I can very much understand if this never gets merged but I really need a solution to tags. 

- for now behind a feature flags `tags`
- it will generate artifacts when used with other serializers
- conceptually implemented in the same way as `rust-cbor` does it
- will be a breaking change as
  - tags now get emitted as `u64` values
  - the `self describing` tag gets emitted as well, but this could be changed
- I have not added `Tagged` to the `Value` type yet, unclear if this needs to happen or not

## Example Code

```rust
#[derive(Debug, PartialEq)]
struct MyTaggedValue(Vec<u8>);

impl MyTaggedValue {
    fn tag() -> u64 {
        9
    }
}

impl Serialize for MyTaggedValue {
    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: Serializer,
    {
        serde_cbor::EncodeCborTag::new(Self::tag(), &self.0).serialize(serializer)
    }
}

impl<'de> Deserialize<'de> for MyTaggedValue {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        let wrapper = serde_cbor::EncodeCborTag::deserialize(deserializer)?;
        if wrapper.tag() != Self::tag() {
            return Err(serde::de::Error::custom(format!(
                "Invalid tag: {}, expected {}",
                wrapper.tag(),
                Self::tag()
            )));
        }
        Ok(MyTaggedValue(wrapper.value()))
    }
}

// Roundtrip with custom type

let value = MyTaggedValue(vec![1, 2, 3]);

// C9       # tag(9)
//    83    # array(3)
//       01 # unsigned(1)
//       02 # unsigned(2)
//       03 # unsigned(3)

let bytes = b"\xC9\x83\x01\x02\x03";
assert_eq!(&to_vec(&value).unwrap()[..], bytes);
let res: MyTaggedValue = serde_cbor::de::from_slice_with_scratch(bytes, &mut []).unwrap();

assert_eq!(res, value);
```

Ref #56 
