### PR TITLE
Correctly set value::Serializer's is_human_readable

### DIFF
--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -240,6 +240,11 @@ impl serde::Serializer for Serializer {
             map: BTreeMap::new(),
         })
     }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 pub struct SerializeVec {


### PR DESCRIPTION
Fixes #136.

I hope this can go into 0.10.1 soon.