### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "pyfisch/cbor" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-byteorder = { version = "1.0.0", default-features = false }
 half = "1.2.0"
 serde = { version = "1.0.14", default-features = false }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,5 @@
 //! Deserialization.
 
-use byteorder::{BigEndian, ByteOrder};
 use core::f32;
 use core::marker::PhantomData;
 use core::result;
@@ -263,20 +262,23 @@ where
 
     fn parse_u16(&mut self) -> Result<u16> {
         let mut buf = [0; 2];
-        self.read.read_into(&mut buf)?;
-        Ok(BigEndian::read_u16(&buf))
+        self.read
+            .read_into(&mut buf)
+            .map(|()| u16::from_be_bytes(buf))
     }
 
     fn parse_u32(&mut self) -> Result<u32> {
         let mut buf = [0; 4];
-        self.read.read_into(&mut buf)?;
-        Ok(BigEndian::read_u32(&buf))
+        self.read
+            .read_into(&mut buf)
+            .map(|()| u32::from_be_bytes(buf))
     }
 
     fn parse_u64(&mut self) -> Result<u64> {
         let mut buf = [0; 8];
-        self.read.read_into(&mut buf)?;
-        Ok(BigEndian::read_u64(&buf))
+        self.read
+            .read_into(&mut buf)
+            .map(|()| u64::from_be_bytes(buf))
     }
 
     fn parse_bytes<V>(&mut self, len: usize, visitor: V) -> Result<V::Value>
@@ -542,15 +544,11 @@ where
     }
 
     fn parse_f32(&mut self) -> Result<f32> {
-        let mut buf = [0; 4];
-        self.read.read_into(&mut buf)?;
-        Ok(BigEndian::read_f32(&buf))
+        self.parse_u32().map(|i| f32::from_bits(i))
     }
 
     fn parse_f64(&mut self) -> Result<f64> {
-        let mut buf = [0; 8];
-        self.read.read_into(&mut buf)?;
-        Ok(BigEndian::read_f64(&buf))
+        self.parse_u64().map(|i| f64::from_bits(i))
     }
 
     // Don't warn about the `unreachable!` in case

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -5,7 +5,6 @@ pub use crate::write::IoWrite;
 pub use crate::write::{SliceWrite, Write};
 
 use crate::error::{Error, Result};
-use byteorder::{BigEndian, ByteOrder};
 use half::f16;
 use serde::ser::{self, Serialize};
 #[cfg(feature = "std")]
@@ -123,7 +122,7 @@ where
     #[inline]
     pub fn self_describe(&mut self) -> Result<()> {
         let mut buf = [6 << 5 | 25, 0, 0];
-        BigEndian::write_u16(&mut buf[1..], 55799);
+        (&mut buf[1..]).copy_from_slice(&55799u16.to_be_bytes());
         self.writer.write_all(&buf).map_err(|e| e.into())
     }
 
@@ -150,7 +149,7 @@ where
             self.write_u8(major, value as u8)
         } else {
             let mut buf = [major << 5 | 25, 0, 0];
-            BigEndian::write_u16(&mut buf[1..], value);
+            (&mut buf[1..]).copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
     }
@@ -161,7 +160,7 @@ where
             self.write_u16(major, value as u16)
         } else {
             let mut buf = [major << 5 | 26, 0, 0, 0, 0];
-            BigEndian::write_u32(&mut buf[1..], value);
+            (&mut buf[1..]).copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
     }
@@ -172,7 +171,7 @@ where
             self.write_u32(major, value as u32)
         } else {
             let mut buf = [major << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
-            BigEndian::write_u64(&mut buf[1..], value);
+            (&mut buf[1..]).copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
     }
@@ -316,11 +315,11 @@ where
             self.writer.write_all(&[0xf9, 0x7e, 0x00])
         } else if f32::from(f16::from_f32(value)) == value {
             let mut buf = [0xf9, 0, 0];
-            BigEndian::write_u16(&mut buf[1..], f16::from_f32(value).to_bits());
+            (&mut buf[1..]).copy_from_slice(&f16::from_f32(value).to_bits().to_be_bytes());
             self.writer.write_all(&buf)
         } else {
             let mut buf = [0xfa, 0, 0, 0, 0];
-            BigEndian::write_f32(&mut buf[1..], value);
+            (&mut buf[1..]).copy_from_slice(&value.to_bits().to_be_bytes());
             self.writer.write_all(&buf)
         }
         .map_err(|e| e.into())
@@ -333,7 +332,7 @@ where
             self.serialize_f32(value as f32)
         } else {
             let mut buf = [0xfb, 0, 0, 0, 0, 0, 0, 0, 0];
-            BigEndian::write_f64(&mut buf[1..], value);
+            (&mut buf[1..]).copy_from_slice(&value.to_bits().to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
     }


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not strictly needed since 1.32; the change does bump the minimum rust version, though. IMHO this is worth losing `byteorder`, which gets pulled in a lot via `cbor`.