### PR TITLE
pub no_std fmt::write

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -4,6 +4,9 @@
 pub use crate::write::IoWrite;
 pub use crate::write::{SliceWrite, Write};
 
+#[cfg(not(feature = "std"))]
+pub use crate::write::FmtWriter;
+
 use crate::error::{Error, Result};
 use byteorder::{BigEndian, ByteOrder};
 use half::f16;

--- a/src/write.rs
+++ b/src/write.rs
@@ -192,7 +192,9 @@ impl<'a, W: fmt::Write> Write for FmtWriter<'a, W> {
     type Error = fmt::Error;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
-        self.0.write_str(core::str::from_utf8(buf).unwrap())
+        // Is safe as internally an &[u8] is needed, but not allowed by the interface
+        self.0
+            .write_str(unsafe { core::str::from_utf8_unchecked(buf) })
     }
 }
 


### PR DESCRIPTION

We have an [interrupted dma coming](https://github.com/nrf-rs/nrf52-hal/pull/102) into embedded hal shortly that uses a statically allocated pool to write out to dma. Serializers like your recent no_std support (thanks!) are an obvious application.

I can get a mut u8 slice and thus use your existing api just fine, either naively with an extra buffer, or even without but for various reasons with the slice api we have to zero the (maybeuninit) buffer which is a little extra overhead thats seems unnecessary . 

It DOES [implement fmt::Write](https://github.com/nrf-rs/nrf52-hal/pull/102/files#diff-4d88bb5a92b057ef97d83602b2d76b30R448) which without core::io::write seems to be the only trait no_std can agree upon?

You do have some kind of fmt::Write implemented.. but its not public and I dont understand it.. it just calls back in upon itself.. 
Frankly I barely understand all the sealed + generics + lifetimes, but I made this new FmtWriter that does what Im trying to accomplish with the end result is I can use fmt::write trait instead of a slice
```
        let mut node = UarteDMAPoolNode::new();
        {
            let writer = FmtWriter::new(&mut node);
            let mut ser = Serializer::new(writer);
            &"aabasdf".serialize(&mut ser).unwrap();
        }
        let b = UarteDMAPool::alloc().unwrap().init(node);
        resources.PRODUCER.enqueue(b).unwrap();
        rtfm::pend(interrupt::UARTE0_UART0);
```

Thoughts. Am I missing something about the existing FmtWrite?
Thanks!