### PR TITLE
Support 128-bit integers

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -280,7 +280,7 @@ where
         Ok(BigEndian::read_u64(&buf))
     }
 
-    fn parse_bigint<V>(&mut self, visitor: V, signed: bool) -> Result<V::Value>
+    fn parse_bigint<V>(&mut self, signed: bool, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
@@ -890,7 +890,7 @@ where
         match self.peek()? {
             Some(tag @ 0xc2..=0xc3) => {
                 self.consume();
-                self.parse_bigint(visitor, tag == 0xc3 /* signed */)
+                self.parse_bigint(tag == 0xc3 /* signed */, visitor)
             }
             _ => self.parse_value(visitor),
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -281,16 +281,16 @@ where
     }
 
     fn try_parse_u128(&mut self) -> Result<Option<u128>> {
-        // ^ Only *try* parse because the value could be a non-u128 byte array.
+        // ^ Only *try* parse because the value could be a non-u128 bytestring.
         let desc = match self.peek()? {
             Some(desc) => desc,
             None => return Ok(None),
         };
         let ty = desc >> 5;
         if ty != 2 {
-            return Ok(None);
+            return Ok(None); // not a bytestring
         }
-        let len = desc & 0x1fu8;
+        let len = desc & 0x1f;
         if len > 16 {
             return Ok(None);
         }
@@ -731,7 +731,7 @@ where
                 Some(value) => visitor.visit_i128(-1 - value as i128),
                 None => self.parse_value(visitor),
             },
-            0xc1 | 0xc4..=0xd7 => self.parse_value(visitor),
+            0xc0 | 0xc1 | 0xc4..=0xd7 => self.parse_value(visitor),
             0xd8 => {
                 self.parse_u8()?;
                 self.parse_value(visitor)
@@ -771,8 +771,7 @@ where
             }
             0xfc..=0xfe => Err(self.error(ErrorCode::UnassignedCode)),
             0xff => Err(self.error(ErrorCode::UnexpectedCode)),
-
-            _ => unreachable!(),
+            _ => unreachable!(), // Remove this once minimum supported rustc version is 1.33.0.
         }
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -183,13 +183,13 @@ where
         if len <= 8 {
             self.write_u64(tag - 2, value as u64)
         } else {
+            let mut buf = [0u8; 2 + 16];
+            BigEndian::write_u128(&mut buf[2..], value);
+            let hdr_offset = 16 - len as usize;
+            buf[hdr_offset] = 6 << 5 | tag;
+            buf[hdr_offset + 1] = 2 << 5 | len as u8;
             self.writer
-                .write_all(&[6 << 5 | tag, 2 << 5 | len as u8])
-                .map_err(|e| e.into())?;
-            let mut buf = [0u8; 16];
-            BigEndian::write_u128(&mut buf, value);
-            self.writer
-                .write_all(&buf[(16 - len) as usize..])
+                .write_all(&buf[hdr_offset..])
                 .map_err(|e| e.into())
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -183,10 +183,14 @@ where
         if len <= 8 {
             self.write_u64(tag - 2, value as u64)
         } else {
-            self.writer.write_all(&[6 << 5 | tag, 2 << 5 | len as u8]).map_err(|e| e.into())?;
+            self.writer
+                .write_all(&[6 << 5 | tag, 2 << 5 | len as u8])
+                .map_err(|e| e.into())?;
             let mut buf = [0u8; 16];
             BigEndian::write_u128(&mut buf, value);
-            self.writer.write_all(&buf[(16 - len) as usize..]).map_err(|e| e.into())
+            self.writer
+                .write_all(&buf[(16 - len) as usize..])
+                .map_err(|e| e.into())
         }
     }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -68,6 +68,14 @@ impl<'de> de::Deserialize<'de> for Value {
             }
 
             #[inline]
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Value::Unsigned(v))
+            }
+
+            #[inline]
             fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
             where
                 E: de::Error,

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -21,6 +21,7 @@ impl serde::Serialize for Value {
     {
         match *self {
             Value::Integer(v) => serializer.serialize_i128(v),
+            Value::Unsigned(v) => serializer.serialize_u128(v),
             Value::Bytes(ref v) => serializer.serialize_bytes(&v),
             Value::Text(ref v) => serializer.serialize_str(&v),
             Value::Array(ref v) => v.serialize(serializer),
@@ -78,22 +79,27 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<Value, Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_u128(u128::from(value))
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<Value, Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_u128(u128::from(value))
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<Value, Error> {
-        self.serialize_u64(u64::from(value))
+        self.serialize_u128(u128::from(value))
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<Value, Error> {
-        Ok(Value::Integer(value.into()))
+        self.serialize_u128(u128::from(value))
+    }
+
+    #[inline]
+    fn serialize_u128(self, value: u128) -> Result<Value, Error> {
+        Ok(Value::Unsigned(value))
     }
 
     #[inline]

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -182,5 +182,23 @@ mod std_tests {
         -18446744073709551616i128,
         "3BFFFFFFFFFFFFFFFF"
     );
-    testcase!(test_u128, u128, 17, "11");
+    testcase!(
+        test_i128_c,
+        i128,
+        -18446744073709551617i128,
+        "C349010000000000000000"
+    );
+    testcase!(test_u128_a, u128, 17, "11");
+    testcase!(
+        test_u128_b,
+        u128,
+        u128::max_value(),
+        "C250FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    );
+    testcase!(
+        test_u128_c,
+        u128,
+        u128::from(u64::max_value()),
+        "1BFFFFFFFFFFFFFFFF"
+    );
 }


### PR DESCRIPTION
This PR adds support for `u128` and `i128` in accordance with [§2.4.2 of the CBOR spec](https://tools.ietf.org/html/rfc7049#section-2.4.2).