### PR TITLE
Don't abort build sucessfully when clippy fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - rustup target add thumbv7em-none-eabihf     # Any target that does not have a standard library will do
 script:
   - cargo fmt --all -- --check
-  - (rustup component add clippy && cargo clippy --all --all-features -- -D clippy::all) || exit 0
+  - (rustup component add clippy && cargo clippy --all --all-features -- -D clippy::all) || true
   - cargo build
   - cargo test
   - cargo build --no-default-features --target thumbv7em-none-eabihf # Test we can build a platform that does not have std.


### PR DESCRIPTION
Before, if the `clippy` check would fail `exit 0` would be called which exited the test script. This meant that all subsequent steps would be skipped and the _build would pass_.

Now instead of exiting the test script we just make sure that the script always return a zero exit code.