### PR TITLE
Revert .travis.yml to old version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ before_script:
   - rustup target add thumbv7em-none-eabihf     # Any target that does not have a standard library will do
 script:
   - cargo fmt --all -- --check
-  - (rustup component add clippy && cargo clippy --all -- -D clippy::all) || true
+  - (rustup component add clippy && cargo clippy --all --all-features -- -D clippy::all) || exit 0
   - cargo build
   - cargo test
-  - cargo build --no-default-features --features alloc --target thumbv7em-none-eabihf # Test we can build a platform that does not have std.
+  - cargo build --no-default-features --target thumbv7em-none-eabihf # Test we can build a platform that does not have std.
   - cargo test --no-default-features --lib --tests # Run no_std tests
-  - [[ $TRAVIS_RUST_VERSION != "1.31.0" ]] && cargo build --no-default-features --features alloc
   - cargo build --features unsealed_read_write # The crate should still build when the unsealed_read_write feature is enabled.
   - cargo build --no-default-features --features unsealed_read_write # The crate should still build when the unsealed_read_write feature is enabled and std disabled.


### PR DESCRIPTION
Travis CI currently says " Could not parse pyfisch/cbor/.travis.yml"