### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -22,7 +22,7 @@ mod std_tests {
             -65537,
             -4294967296,
         ]
-        .into_iter()
+        .iter()
         .map(|i| Value::Integer(*i))
         .collect::<Vec<_>>();
 
@@ -35,7 +35,7 @@ mod std_tests {
     #[test]
     fn string_canonical_sort_order() {
         let expected = ["", "a", "b", "aa"]
-            .into_iter()
+            .iter()
             .map(|s| Value::Text(s.to_string()))
             .collect::<Vec<_>>();
 

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -39,7 +39,7 @@ mod std_tests {
                 (format!("key3"), format!("value3")),
                 (format!("key4"), format!("value4")),
             ]
-            .into_iter()
+            .iter()
             .cloned(),
         );
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.