### PR TITLE
Use three integer Value variants

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1209,7 +1209,7 @@ where
 /// ];
 /// let mut it = Deserializer::from_slice(&data[..]).into_iter::<Value>();
 /// assert_eq!(
-///     Value::Integer(1),
+///     Value::UnsignedInteger(1),
 ///     it.next().unwrap().unwrap()
 /// );
 /// assert_eq!(

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -56,7 +56,7 @@ impl<'de> de::Deserialize<'de> for Value {
             where
                 E: de::Error,
             {
-                Ok(Value::Integer(v.into()))
+                Ok(Value::UnsignedInteger(v))
             }
 
             #[inline]
@@ -64,7 +64,7 @@ impl<'de> de::Deserialize<'de> for Value {
             where
                 E: de::Error,
             {
-                Ok(Value::Integer(v.into()))
+                Ok(Value::SignedInteger(v))
             }
 
             #[inline]
@@ -72,7 +72,17 @@ impl<'de> de::Deserialize<'de> for Value {
             where
                 E: de::Error,
             {
-                Ok(Value::Integer(v))
+                if v > 2i128.pow(64)-1 || v < -(2i128.pow(64)) {
+                    return Err(E::custom("Integer value must be between -2^64 and 2^64-1"));
+                }
+
+                if v >= 0 {
+                    Ok(Value::UnsignedInteger(v as u64))
+                } else if v >= 2i128.pow(63) {
+                    Ok(Value::SignedInteger(v as i64))
+                } else {
+                    Ok(Value::LargeSignedInteger(v))
+                }
             }
 
             #[inline]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -72,7 +72,7 @@ impl<'de> de::Deserialize<'de> for Value {
             where
                 E: de::Error,
             {
-                if v > 2i128.pow(64)-1 || v < -(2i128.pow(64)) {
+                if v > 2i128.pow(64) - 1 || v < -(2i128.pow(64)) {
                     return Err(E::custom("Integer value must be between -2^64 and 2^64-1"));
                 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -96,8 +96,12 @@ impl Ord for Value {
             // Use i128 to avoid possible panic if abs() is called on -2^63
             (SignedInteger(a), SignedInteger(b)) => i128::from(*a).abs().cmp(&i128::from(*b).abs()),
             (LargeSignedInteger(a), LargeSignedInteger(b)) => a.abs().cmp(&b.abs()),
-            (UnsignedInteger(a), SignedInteger(b)) => i128::from(*a).abs().cmp(&i128::from(*b).abs()),
-            (SignedInteger(a), UnsignedInteger(b)) => i128::from(*a).abs().cmp(&i128::from(*b).abs()),
+            (UnsignedInteger(a), SignedInteger(b)) => {
+                i128::from(*a).abs().cmp(&i128::from(*b).abs())
+            }
+            (SignedInteger(a), UnsignedInteger(b)) => {
+                i128::from(*a).abs().cmp(&i128::from(*b).abs())
+            }
             (LargeSignedInteger(a), UnsignedInteger(b)) => a.abs().cmp(&i128::from(*b).abs()),
             (UnsignedInteger(a), LargeSignedInteger(b)) => i128::from(*a).abs().cmp(&b.abs()),
             (SignedInteger(a), LargeSignedInteger(b)) => i128::from(*a).abs().cmp(&b.abs()),
@@ -159,14 +163,14 @@ impl Value {
                 } else {
                     1
                 }
-            },
+            }
             LargeSignedInteger(v) => {
                 if *v >= 0 {
                     0
                 } else {
                     1
                 }
-            },
+            }
             Float(_) => 7,
             Bytes(_) => 2,
             Text(_) => 3,

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -75,7 +75,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_i128(self, value: i128) -> Result<Value, Error> {
-        if value > 2i128.pow(64)-1 || value < -(2i128.pow(64)) {
+        if value > 2i128.pow(64) - 1 || value < -(2i128.pow(64)) {
             return Err(Error::message("The number can't be stored in CBOR"));
         }
 

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -23,7 +23,7 @@ mod std_tests {
             -4294967296,
         ]
         .iter()
-        .map(|i| Value::Integer(*i))
+        .map(|i| Value::SignedInteger(*i))
         .collect::<Vec<_>>();
 
         let mut sorted = expected.clone();
@@ -71,8 +71,8 @@ mod std_tests {
     #[test]
     fn major_type_canonical_sort_order() {
         let expected = vec![
-            Value::Integer(0),
-            Value::Integer(-1),
+            Value::UnsignedInteger(0),
+            Value::SignedInteger(-1),
             Value::Bytes(vec![]),
             Value::Text("".to_string()),
             Value::Null,
@@ -88,13 +88,13 @@ mod std_tests {
     fn test_rfc_example() {
         // See: https://tools.ietf.org/html/draft-ietf-cbor-7049bis-04#section-4.10
         let expected = vec![
-            Value::Integer(10),
-            Value::Integer(100),
-            Value::Integer(-1),
+            Value::UnsignedInteger(10),
+            Value::UnsignedInteger(100),
+            Value::SignedInteger(-1),
             Value::Text("z".to_owned()),
             Value::Text("aa".to_owned()),
-            Value::Array(vec![Value::Integer(100)]),
-            Value::Array(vec![Value::Integer(-1)]),
+            Value::Array(vec![Value::UnsignedInteger(100)]),
+            Value::Array(vec![Value::SignedInteger(-1)]),
             Value::Bool(false),
         ];
         let mut sorted = expected.clone();

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -87,19 +87,19 @@ mod std_tests {
     #[test]
     fn test_numbers1() {
         let value: error::Result<Value> = de::from_slice(&[0x00]);
-        assert_eq!(value.unwrap(), Value::Integer(0));
+        assert_eq!(value.unwrap(), Value::UnsignedInteger(0));
     }
 
     #[test]
     fn test_numbers2() {
         let value: error::Result<Value> = de::from_slice(&[0x1a, 0x00, 0xbc, 0x61, 0x4e]);
-        assert_eq!(value.unwrap(), Value::Integer(12345678));
+        assert_eq!(value.unwrap(), Value::UnsignedInteger(12345678));
     }
 
     #[test]
     fn test_numbers3() {
         let value: error::Result<Value> = de::from_slice(&[0x39, 0x07, 0xde]);
-        assert_eq!(value.unwrap(), Value::Integer(-2015));
+        assert_eq!(value.unwrap(), Value::SignedInteger(-2015));
     }
 
     #[test]
@@ -120,9 +120,9 @@ mod std_tests {
         assert_eq!(
             value.unwrap(),
             Value::Array(vec![
-                Value::Integer(1),
-                Value::Integer(2),
-                Value::Integer(3)
+                Value::UnsignedInteger(1),
+                Value::UnsignedInteger(2),
+                Value::UnsignedInteger(3)
             ])
         );
     }
@@ -133,10 +133,10 @@ mod std_tests {
         assert_eq!(
             value.unwrap(),
             Value::Array(vec![
-                Value::Integer(1),
+                Value::UnsignedInteger(1),
                 Value::Array(vec![
-                    Value::Integer(2),
-                    Value::Array(vec![Value::Integer(3)])
+                    Value::UnsignedInteger(2),
+                    Value::Array(vec![Value::UnsignedInteger(3)])
                 ])
             ])
         );
@@ -158,10 +158,10 @@ mod std_tests {
     fn test_indefinite_object() {
         let value: error::Result<Value> = de::from_slice(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff");
         let mut object = BTreeMap::new();
-        object.insert(Value::Text("a".to_owned()), Value::Integer(1));
+        object.insert(Value::Text("a".to_owned()), Value::UnsignedInteger(1));
         object.insert(
             Value::Text("b".to_owned()),
-            Value::Array(vec![Value::Integer(2), Value::Integer(3)]),
+            Value::Array(vec![Value::UnsignedInteger(2), Value::UnsignedInteger(3)]),
         );
         assert_eq!(value.unwrap(), Value::Map(object));
     }
@@ -172,9 +172,9 @@ mod std_tests {
         assert_eq!(
             value.unwrap(),
             Value::Array(vec![
-                Value::Integer(1),
-                Value::Integer(2),
-                Value::Integer(3)
+                Value::UnsignedInteger(1),
+                Value::UnsignedInteger(2),
+                Value::UnsignedInteger(3)
             ])
         );
     }
@@ -246,9 +246,9 @@ mod std_tests {
         assert_eq!(
             value,
             vec![
-                Value::Integer(123456789959),
-                Value::Integer(-34567897654325468),
-                Value::Integer(-456787678),
+                Value::UnsignedInteger(123456789959),
+                Value::SignedInteger(-34567897654325468),
+                Value::SignedInteger(-456787678),
                 Value::Bool(true),
                 Value::Null,
                 Value::Null,
@@ -330,7 +330,7 @@ mod std_tests {
     fn stream_deserializer() {
         let slice = b"\x01\x66foobar";
         let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
-        assert_eq!(Value::Integer(1), it.next().unwrap().unwrap());
+        assert_eq!(Value::UnsignedInteger(1), it.next().unwrap().unwrap());
         assert_eq!(
             Value::Text("foobar".to_string()),
             it.next().unwrap().unwrap()
@@ -342,7 +342,7 @@ mod std_tests {
     fn stream_deserializer_eof() {
         let slice = b"\x01\x66foob";
         let mut it = Deserializer::from_slice(slice).into_iter::<Value>();
-        assert_eq!(Value::Integer(1), it.next().unwrap().unwrap());
+        assert_eq!(Value::UnsignedInteger(1), it.next().unwrap().unwrap());
         assert!(it.next().unwrap().unwrap_err().is_eof());
     }
 

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -159,7 +159,10 @@ mod std_tests {
 
         // tuple-variants serialize like ["<variant>", values..]
         let number_s = to_vec_legacy(&Bar::Number(42)).unwrap();
-        let number_vec = vec![Value::Text("Number".to_string()), Value::UnsignedInteger(42)];
+        let number_vec = vec![
+            Value::Text("Number".to_string()),
+            Value::UnsignedInteger(42),
+        ];
         let number_vec_s = to_vec_legacy(&number_vec).unwrap();
         assert_eq!(number_s, number_vec_s);
 

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -159,7 +159,7 @@ mod std_tests {
 
         // tuple-variants serialize like ["<variant>", values..]
         let number_s = to_vec_legacy(&Bar::Number(42)).unwrap();
-        let number_vec = vec![Value::Text("Number".to_string()), Value::Integer(42)];
+        let number_vec = vec![Value::Text("Number".to_string()), Value::UnsignedInteger(42)];
         let number_vec_s = to_vec_legacy(&number_vec).unwrap();
         assert_eq!(number_s, number_vec_s);
 
@@ -175,8 +175,8 @@ mod std_tests {
         // struct-variants serialize like ["<variant>", {struct..}]
         let point_s = to_vec_legacy(&Bar::Point { x: 5, y: -5 }).unwrap();
         let mut struct_map = BTreeMap::new();
-        struct_map.insert(Value::Text("x".to_string()), Value::Integer(5));
-        struct_map.insert(Value::Text("y".to_string()), Value::Integer(-5));
+        struct_map.insert(Value::Text("x".to_string()), Value::UnsignedInteger(5));
+        struct_map.insert(Value::Text("y".to_string()), Value::SignedInteger(-5));
         let point_vec = vec![
             Value::Text("Point".to_string()),
             Value::Map(struct_map.clone()),


### PR DESCRIPTION
* `UnsignedInteger(u64)`: for all non-negative values.
 * `SignedInteger(i64)`: for negative values that fit in a i64.
 * `LargeSignedInteger(i128)`: for negative values that can't be represented by i64.

 This should fix #140.