### PR TITLE
Add roundtrip example test case.

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,32 @@
+#[macro_use]
+extern crate serde_derive;
+
+use serde_cbor;
+use serde_cbor::de;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct MyStuff {
+    #[serde(flatten)]
+    data: MyStuffType,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum MyStuffType {
+    ver1 {
+        x: f64,
+    },
+    ver2
+}
+
+#[test]
+/// Test roundtrip operation on a serde data structure.
+fn test_roundtrip() {
+    let stuff1 = MyStuff {
+        data: MyStuffType::ver1 {
+            x: 2.5
+        }
+    };
+    let data_bytes = serde_cbor::to_vec(&stuff1).unwrap();
+    let stuff2 = serde_cbor::from_slice(&data_bytes).unwrap();
+    assert_eq!(stuff1, stuff2);
+}


### PR DESCRIPTION
Hi, I was wondering whether this testcase should work or not? What am I doing wrong in this case, or is this a bug?

```
---- test_roundtrip stdout ----
thread 'test_roundtrip' panicked at 'called `Result::unwrap()` on an `Err` value: ErrorImpl { code: Message("invalid type: floating point `2.5`, expected f64"), offset: 0 }', src/libcore/result.rs:1165:5
```