### PR TITLE
Clarify packed format and add a to_vec_minimal helper method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,13 +63,25 @@
 //!
 //! The CBOR API also provides an enum `serde_cbor::Value`.
 //!
-//! # Packed Encoding
+//! # Smaller Encodings
 //! When serializing structs or enums in CBOR the keys or enum variant names will be serialized
 //! as string keys to a map. Especially in embedded environments this can increase the file
-//! size too much. In packed encoding the keys and variants will be serialized as variable sized
-//! integers. The first 24 entries in any struct consume only a single byte!
+//! size too much. Serde CBOR provides two encodings that reduce the size of encoded structs and
+//! enums.
+//!
+//! ## Packed Encoding
+//! In packed encoding all struct keys, as well as any enum variant that has no data, will
+//! be serialized as variable sized integers. The first 24 entries in any struct consume only a
+//! single byte!  Packed encoding uses serde's preferred
+//! [externally tagged enum format](https://serde.rs/enum-representations.html) and therefore
+//! serializes enum variant names as string keys when that variant contains data.
 //! To serialize a document in this format use `Serializer::new(writer).packed_format()` or
 //! the shorthand `ser::to_vec_packed`. The deserialization works without any changes.
+//!
+//! ## Minimal Encoding
+//! If you want the smallest encoding possible, even though enums will no longer be externally
+//! tagged, use `Serializer::new(writer).packed_format().legacy_enums()` or the shorthand
+//! `ser::to_vec_minimal`. Like `to_vec_packed`, the deserialization works without any changes.
 //!
 //! # Self describing documents
 //! In some contexts different formats are used but there is no way to declare the format used

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -26,7 +26,7 @@ where
     Ok(vec)
 }
 
-/// Serializes a value to a vector in packed format.
+/// Serializes a value to a vector in packed format using externally tagged enums.
 #[cfg(feature = "std")]
 pub fn to_vec_packed<T>(value: &T) -> Result<Vec<u8>>
 where
@@ -34,6 +34,17 @@ where
 {
     let mut vec = Vec::new();
     value.serialize(&mut Serializer::new(&mut IoWrite::new(&mut vec)).packed_format())?;
+    Ok(vec)
+}
+
+/// Serializes a value to a vector in the most compressed format, albeit enums are not externally tagged.
+#[cfg(feature = "std")]
+pub fn to_vec_minimal<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut vec = Vec::new();
+    value.serialize(&mut Serializer::new(&mut IoWrite::new(&mut vec)).packed_format().legacy_enums())?;
     Ok(vec)
 }
 


### PR DESCRIPTION
This is the PR that includes the `to_vec_minimal` helper that you didn't ask for.

If you don't want it, I'll take it out and revert most of the packed encoding documentation, but add a paragraph or two that basically says the same thing as my Minimal Encoding paragraph, but instead of mentioning `to_vec_minimal` as part of serde-cbor I'll just show how the end-user can make such a beast.

I don't have a strong preference one way or the other. On one hand if `to_vec_minimal` is adopted and some other minimization options are added, then `to_vec_minimal` can be updated to use those techniques and everyone using `to_vec_minimal` automatically gets the added compression. On the other hand, every extra method in an API is some degree of burden on the maintainers.