### PR TITLE
Allow enabling `serde/std` without also requiring `serde_cbor/std` to be enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ script:
     || cargo build --no-default-features --features alloc
   - cargo build --features unsealed_read_write # The crate should still build when the unsealed_read_write feature is enabled.
   - cargo build --no-default-features --features unsealed_read_write # The crate should still build when the unsealed_read_write feature is enabled and std disabled.
+  - cargo build --no-default-features --features serde/std # The crate should still build when serde/std is enabled and std disabled.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,6 @@ use core::result;
 use serde::de;
 use serde::ser;
 #[cfg(feature = "std")]
-use std::error;
-#[cfg(feature = "std")]
 use std::io;
 
 /// This type represents all possible errors that can occur when serializing or deserializing CBOR
@@ -192,9 +190,9 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+impl ser::StdError for Error {
+    #[cfg(feature = "std")]
+    fn source(&self) -> Option<&(dyn ser::StdError + 'static)> {
         match self.0.code {
             ErrorCode::Io(ref err) => Some(err),
             _ => None,


### PR DESCRIPTION
Currently `serde_cbor`'s `std` feature must be enabled if `serde/std` is also enabled, even if `serde/std` is enabled separately by another crate somewhere else in the dependency tree.

However, this doesn't necessarily need to be the case. `serde` provides a `StdError` type in order to get around this (see https://github.com/serde-rs/serde/pull/1620). This is a type provided by `serde` as a re-export of `std::error::Error` when `serde/std` is enabled and as an export of a custom `serde::std_error::Error` type with the same interface as `std::error::Error` when `serde/std` is not enabled. By conforming to `serde::ser::StdError` instead of `std::error::Error`, `serde_cbor` can rely on the `std`/`no_std` state of `serde` rather than requiring that both libraries' `std` feature be either both enabled or both disabled.

This allows `serde_cbor` to be in `no_std` even if `serde/std` is enabled. While this might not make a ton of sense at first glance, this change would lead to a much more robust dependency mechanism when `serde` and `serde_cbor` are involved, by allowing a crate to depend on `serde_cbor` with default features disabled and not have to worry if another crate (maybe even higher up in the dependency graph) enables `serde/std` completely independently. Ideally, the ultimate goal is that features are additive and not dependent on the state of other features laterally in the dependency graph.

This PR does 2 things:
* Changes the type of the std error that `serde_cbor::Error` conforms to from `std::error::Error` to `serde::ser::StdError`.
* Adds a line to `.travis.yml` to test building with `serde/std` enabled and `serde_cbor`'s default features disabled in order to test that this configuration is buildable.