### PR TITLE
Implement `de::from_slice_count`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,10 @@ impl Error {
         self.0.offset
     }
 
+    pub(crate) fn code(&self) -> &ErrorCode {
+        &self.0.code
+    }
+
     pub(crate) fn syntax(code: ErrorCode, offset: u64) -> Error {
         Error(ErrorImpl { code, offset })
     }


### PR DESCRIPTION
Add a function that deserializes first valid cbor value out of a slice of bytes
and returns the number of consumed bytes.