### PR TITLE
Fix encoding of packed variants in new enum format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,35 +158,6 @@
 //! assert_eq!(cbor.len(), 1);
 //!
 //! let cbor = to_vec_packed(&SecondVariant(0)).unwrap();
-//! assert_eq!(cbor.len(), 16); // Includes 13 bytes of "SecondVariant"
-//! ```
-//!
-//! Serialize using minimal encoding
-//!
-//! ```rust
-//! use serde_derive::{Deserialize, Serialize};
-//! use serde_cbor::{Result, Serializer, ser::{self, IoWrite}};
-//! use WithTwoVariants::*;
-//!
-//! fn to_vec_minimal<T>(value: &T) -> Result<Vec<u8>>
-//! where
-//!     T: serde::Serialize,
-//! {
-//!     let mut vec = Vec::new();
-//!     value.serialize(&mut Serializer::new(&mut IoWrite::new(&mut vec)).packed_format().legacy_enums())?;
-//!     Ok(vec)
-//! }
-//!
-//! #[derive(Debug, Serialize, Deserialize)]
-//! enum WithTwoVariants {
-//!     FirstVariant,
-//!     SecondVariant(u8),
-//! }
-//!
-//! let cbor = to_vec_minimal(&FirstVariant).unwrap();
-//! assert_eq!(cbor.len(), 1);
-//!
-//! let cbor = to_vec_minimal(&SecondVariant(0)).unwrap();
 //! assert_eq!(cbor.len(), 3);
 //! ```
 //!

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -426,7 +426,11 @@ where
     {
         if self.enum_as_map {
             self.write_u64(5, 1u64)?;
-            variant.serialize(&mut *self)?;
+            if self.packed {
+                variant_index.serialize(&mut *self)?;
+            } else {
+                variant.serialize(&mut *self)?;
+            }
         } else {
             self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
             self.serialize_unit_variant(name, variant_index, variant)?;
@@ -464,7 +468,11 @@ where
     ) -> Result<&'a mut Serializer<W>> {
         if self.enum_as_map {
             self.write_u64(5, 1u64)?;
-            variant.serialize(&mut *self)?;
+            if self.packed {
+                variant_index.serialize(&mut *self)?;
+            } else {
+                variant.serialize(&mut *self)?;
+            }
             self.serialize_tuple(len)
         } else {
             self.write_u64(4, (len + 1) as u64)?;


### PR DESCRIPTION
Fixes #187

Legacy enum format supported packed encoding pretty well but with the
switch to new enum format there was a regression (#173).
This commit fixes the new enum format in packed encoding.

For example consider the following structure:
```rust
enum Enum {
    Unit,
    NewType(i32),
    Tuple(i32, i32),
    Struct { x: i32, y: i32 },
}
```

Legacy enum packed encodings are:
```
Empty: <variant number>
NewType: [<variant number>, value]
Tuple: [<variant number>, values..]
Struct: [<variant number>, {<struct>}]
```

Non-legacy enum packed encodings before this commit:
```
Empty: <variant number>
NewType: {"<variant>": value}
Tuple: {"<variant>": [values..]}
Struct: {<variant number>: {<struct>}}
```
Notice how NewType and Tuple store the name instead of variant number.

Fixed after this commit:
```
Empty: <variant number>
NewType: {<variant number>: value}
Tuple: {<variant number>: [values..]}
Struct: {<variant number>: {<struct>}}
```

After this commit the packed encoding can be briefly described as:
All struct fields and enum variants are encoded as their field number
rather than name.
This applies to all types of members (unit, newtype, tuple and struct).