### PR TITLE
Deserialize `undefined` as `None` for `Option`

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -794,7 +794,7 @@ where
         V: de::Visitor<'de>,
     {
         match self.peek()? {
-            Some(0xf6) => {
+            Some(0xf6) | Some(0xf7) => {
                 self.consume();
                 visitor.visit_none()
             }


### PR DESCRIPTION
CBOR knows these two types ([spec](https://www.rfc-editor.org/rfc/rfc8949.html#fpnoconttbl2)):
- `0xf6` => `null`
- `0xf7` => `undefined`

Serde only knows `Null` afaik, or at least the `Value` enum doesn't have anything closer to represent `undefined` than `Null`.

In order for this to work well with `Option` we need to treat `undefined` the same as `null` when deserializing an `Option`.

this popped up when interacting between Rust and JS, when using `{ key: undefined }` in JS and reading it into `struct { key: Option<Foo> }`